### PR TITLE
Add support for powerpc64le systems

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -12,7 +12,7 @@ export CGO_ENABLED=false
 
 rm -rf distrib/
 
-declare -a target_folders=("linux_amd64" "linux_386" "linux_arm" "darwin_amd64" "windows_386" "linux_arm64")
+declare -a target_folders=("linux_amd64" "linux_386" "linux_arm" "darwin_amd64" "windows_386" "linux_arm64" "linux_ppc64le")
 
 mkdir distrib
 


### PR DESCRIPTION
There are no prebuilt packages available for ppc64el (OpenPOWER) systems, despite the software working on those platforms.

OpenPOWER systems are being deployed more widely, especially in education, and having an easy way to install a newer IDE version than the 1.5 version in Debian Experimental would be much appreciated.

See also arduino/Arduino#8778