### PR TITLE
Add CI workflow to check for unapproved Go dependency licenses

### DIFF
--- a/.github/workflows/check-go-dependencies-task.yml
+++ b/.github/workflows/check-go-dependencies-task.yml
@@ -1,0 +1,140 @@
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/check-go-dependencies-task.md
+name: Check Go Dependencies
+
+env:
+  # See: https://github.com/actions/setup-go/tree/main#supported-version-syntax
+  GO_VERSION: "1.17"
+
+# See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows
+on:
+  create:
+  push:
+    paths:
+      - ".github/workflows/check-go-dependencies-task.ya?ml"
+      - ".licenses/**"
+      - ".licensed.json"
+      - ".licensed.ya?ml"
+      - "Taskfile.ya?ml"
+      - "**/.gitmodules"
+      - "**/go.mod"
+      - "**/go.sum"
+  pull_request:
+    paths:
+      - ".github/workflows/check-go-dependencies-task.ya?ml"
+      - ".licenses/**"
+      - ".licensed.json"
+      - ".licensed.ya?ml"
+      - "Taskfile.ya?ml"
+      - "**/.gitmodules"
+      - "**/go.mod"
+      - "**/go.sum"
+  schedule:
+    # Run periodically to catch breakage caused by external changes.
+    - cron: "0 8 * * WED"
+  workflow_dispatch:
+  repository_dispatch:
+
+jobs:
+  run-determination:
+    runs-on: ubuntu-latest
+    outputs:
+      result: ${{ steps.determination.outputs.result }}
+    steps:
+      - name: Determine if the rest of the workflow should run
+        id: determination
+        run: |
+          RELEASE_BRANCH_REGEX="refs/heads/[0-9]+.[0-9]+.x"
+          # The `create` event trigger doesn't support `branches` filters, so it's necessary to use Bash instead.
+          if [[
+            "${{ github.event_name }}" != "create" ||
+            "${{ github.ref }}" =~ $RELEASE_BRANCH_REGEX
+          ]]; then
+            # Run the other jobs.
+            RESULT="true"
+          else
+            # There is no need to run the other jobs.
+            RESULT="false"
+          fi
+
+          echo "::set-output name=result::$RESULT"
+
+  check-cache:
+    needs: run-determination
+    if: needs.run-determination.outputs.result == 'true'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - name: Install licensed
+        uses: jonabc/setup-licensed@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          version: 3.x
+
+      - name: Install Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Install Task
+        uses: arduino/setup-task@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: 3.x
+
+      - name: Update dependencies license metadata cache
+        run: task --silent general:cache-dep-licenses
+
+      - name: Check for outdated cache
+        id: diff
+        run: |
+          git add .
+          if ! git diff --cached --color --exit-code; then
+            echo
+            echo "::error::Dependency license metadata out of sync. See: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/check-go-dependencies-task.md#metadata-cache"
+            exit 1
+          fi
+
+      # Some might find it convenient to have CI generate the cache rather than setting up for it locally
+      - name: Upload cache to workflow artifact
+        if: failure() && steps.diff.outcome == 'failure'
+        uses: actions/upload-artifact@v3
+        with:
+          if-no-files-found: error
+          name: dep-licenses-cache
+          path: .licenses/
+
+  check-deps:
+    needs: run-determination
+    if: needs.run-determination.outputs.result == 'true'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - name: Install licensed
+        uses: jonabc/setup-licensed@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          version: 3.x
+
+      - name: Install Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Install Task
+        uses: arduino/setup-task@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: 3.x
+
+      - name: Check for dependencies with unapproved licenses
+        run: task --silent general:check-dep-licenses

--- a/.licensed.yml
+++ b/.licensed.yml
@@ -1,0 +1,81 @@
+# See: https://github.com/github/licensed/blob/master/docs/configuration.md
+sources:
+  go: true
+
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-dependencies/GPL-3.0/.licensed.yml
+allowed:
+  # The following are based on: https://www.gnu.org/licenses/license-list.html#GPLCompatibleLicenses
+  - gpl-1.0-or-later
+  - gpl-1.0+ # Deprecated ID for `gpl-1.0-or-later`
+  - gpl-2.0-or-later
+  - gpl-2.0+ # Deprecated ID for `gpl-2.0-or-later`
+  - gpl-3.0-only
+  - gpl-3.0 # Deprecated ID for `gpl-3.0-only`
+  - gpl-3.0-or-later
+  - gpl-3.0+ # Deprecated ID for `gpl-3.0-or-later`
+  - lgpl-2.0-or-later
+  - lgpl-2.0+ # Deprecated ID for `lgpl-2.0-or-later`
+  - lgpl-2.1-only
+  - lgpl-2.1 # Deprecated ID for `lgpl-2.1-only`
+  - lgpl-2.1-or-later
+  - lgpl-2.1+ # Deprecated ID for `lgpl-2.1-or-later`
+  - lgpl-3.0-only
+  - lgpl-3.0 # Deprecated ID for `lgpl-3.0-only`
+  - lgpl-3.0-or-later
+  - lgpl-3.0+ # Deprecated ID for `lgpl-3.0-or-later`
+  - fsfap
+  - apache-2.0
+  - artistic-2.0
+  - clartistic
+  - sleepycat
+  - bsl-1.0
+  - bsd-3-clause
+  - cecill-2.0
+  - bsd-3-clause-clear
+  # "Cryptix General License" - no SPDX ID (https://github.com/spdx/license-list-XML/issues/456)
+  - ecos-2.0
+  - ecl-2.0
+  - efl-2.0
+  - eudatagrid
+  - mit
+  - bsd-2-clause # Subsumed by `bsd-2-clause-views`
+  - bsd-2-clause-netbsd # Deprecated ID for `bsd-2-clause`
+  - bsd-2-clause-views # This is the version linked from https://www.gnu.org/licenses/license-list.html#FreeBSD
+  - bsd-2-clause-freebsd # Deprecated ID for `bsd-2-clause-views`
+  - ftl
+  - hpnd
+  - imatix
+  - imlib2
+  - ijg
+  # "Informal license" - this is a general class of license
+  - intel
+  - isc
+  - mpl-2.0
+  - ncsa
+  # "License of Netscape JavaScript" - no SPDX ID
+  - oldap-2.7
+  # "License of Perl 5 and below" - possibly `Artistic-1.0-Perl` ?
+  - cc0-1.0
+  - cc-pddc
+  - psf-2.0
+  - ruby
+  - sgi-b-2.0
+  - smlnj
+  - standardml-nj # Deprecated ID for `smlnj`
+  - unicode-dfs-2015
+  - upl-1.0
+  - unlicense
+  - vim
+  - w3c
+  - wtfpl
+  - lgpl-2.0-or-later with wxwindows-exception-3.1
+  - wxwindows # Deprecated ID for `lgpl-2.0-or-later with wxwindows-exception-3.1`
+  - x11
+  - xfree86-1.1
+  - zlib
+  - zpl-2.0
+  - zpl-2.1
+  # The following are based on individual license text
+  - eupl-1.2
+  - liliq-r-1.1
+  - liliq-rplus-1.1

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # arduinoOTA
 
 [![Check General Formatting status](https://github.com/arduino/arduinoOTA/actions/workflows/check-general-formatting-task.yml/badge.svg)](https://github.com/arduino/arduinoOTA/actions/workflows/check-general-formatting-task.yml)
+[![Check Go Dependencies status](https://github.com/arduino/arduinoOTA/actions/workflows/check-go-dependencies-task.yml/badge.svg)](https://github.com/arduino/arduinoOTA/actions/workflows/check-go-dependencies-task.yml)
 [![Check Go status](https://github.com/arduino/arduinoOTA/actions/workflows/check-go-task.yml/badge.svg)](https://github.com/arduino/arduinoOTA/actions/workflows/check-go-task.yml)
 [![Check npm status](https://github.com/arduino/arduinoOTA/actions/workflows/check-npm-task.yml/badge.svg)](https://github.com/arduino/arduinoOTA/actions/workflows/check-npm-task.yml)
 [![Check Prettier Formatting status](https://github.com/arduino/arduinoOTA/actions/workflows/check-prettier-formatting-task.yml/badge.svg)](https://github.com/arduino/arduinoOTA/actions/workflows/check-prettier-formatting-task.yml)

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -63,6 +63,30 @@ tasks:
     cmds:
       - npx prettier --write .
 
+  # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-dependencies-task/Taskfile.yml
+  general:cache-dep-licenses:
+    desc: Cache dependency license metadata
+    cmds:
+      - |
+        if ! which licensed &>/dev/null; then
+          if [[ {{OS}} == "windows" ]]; then
+            echo "Licensed does not have Windows support."
+            echo "Please use Linux/macOS or download the dependencies cache from the GitHub Actions workflow artifact."
+          else
+            echo "licensed not found or not in PATH. Please install: https://github.com/github/licensed#as-an-executable"
+          fi
+          exit 1
+        fi
+      - licensed cache
+
+  # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-dependencies-task/Taskfile.yml
+  general:check-dep-licenses:
+    desc: Check for unapproved dependency licenses
+    deps:
+      - task: general:cache-dep-licenses
+    cmds:
+      - licensed status
+
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/spell-check-task/Taskfile.yml
   general:check-spelling:
     desc: Check for commonly misspelled words


### PR DESCRIPTION
A task and GitHub Actions workflow are provided here for checking the license types of Go project dependencies.

On every push and pull request that affects relevant files, the CI workflow will use [**Licensed**](https://github.com/github/licensed) to check:

- If the dependency licenses cache is up to date
- If any of the project's dependencies have an unapproved license type.

Approval can be based on:

- [Allowed license type](https://github.com/github/licensed/blob/master/docs/configuration/allowed_licenses.md)
- [Individual dependency](https://github.com/github/licensed/blob/master/docs/configuration/reviewing_dependencies.md)

---

At the current time, the project does not have any external Go package dependencies, so no license dependency license metadata cache is needed. The check is still valuable because it will provide verification of any dependencies which might be introduced by future contributions.