### PR TITLE
Replace mitchellh/go used for macOS notarization

### DIFF
--- a/.github/workflows/release-go-crosscompile-task.yml
+++ b/.github/workflows/release-go-crosscompile-task.yml
@@ -125,14 +125,14 @@ jobs:
 
       - name: Install gon for code signing and app notarization
         run: |
-          wget -q https://github.com/mitchellh/gon/releases/download/v0.2.3/gon_macos.zip
+          wget -q https://github.com/Bearer/gon/releases/download/v0.0.27/gon_macos.zip
           unzip gon_macos.zip -d /usr/local/bin
 
       - name: Write gon config to file
         # gon does not allow env variables in config file (https://github.com/mitchellh/gon/issues/20)
         run: |
           cat > "${{ env.GON_CONFIG_PATH }}" <<EOF
-          # See: https://github.com/mitchellh/gon#configuration-file
+          # See: https://github.com/Bearer/gon#configuration-file
           source = ["${{ env.DIST_DIR }}/${{ env.PROJECT_NAME }}_osx_${{ matrix.artifact.name }}/${{ env.PROJECT_NAME }}"]
           bundle_id = "cc.arduino.${{ env.PROJECT_NAME }}"
 
@@ -151,6 +151,7 @@ jobs:
         env:
           AC_USERNAME: ${{ secrets.AC_USERNAME }}
           AC_PASSWORD: ${{ secrets.AC_PASSWORD }}
+          AC_PROVIDER: ${{ secrets.AC_PROVIDER }}
         run: |
           gon "${{ env.GON_CONFIG_PATH }}"
 


### PR DESCRIPTION
An excellent tool named [gon](https://github.com/mitchellh/gon) was used to perform the notarization.
the latest stable release of gon uses the altool command-line utility for notarization:
https://github.com/mitchellh/gon/blob/v0.2.5/notarize/upload.go#L41

Using altool for notarization is now deprecated by Apple and support for notarization via this tool is scheduled to be disabled 2023-11-01:
https://developer.apple.com/news/?id=y5mjxqmn

Furthermore, gon was archived.

I switched to https://github.com/Bearer/gon that has included https://github.com/mitchellh/gon/pull/72, hoping the maintainers will take the responsibility of maintaining the project.
I added also `AC_PROVIDER` env var which is mandatory with the new notarytool.

See https://github.com/arduino/tooling-project-assets/issues/359