### PR TITLE
Configure dependency license check workflows to allow "Licensed" install via Gem

### DIFF
--- a/.github/workflows/check-go-dependencies-task.yml
+++ b/.github/workflows/check-go-dependencies-task.yml
@@ -69,6 +69,12 @@ jobs:
         with:
           submodules: recursive
 
+      # This is required to allow licensee/setup-licensed to install Licensed via Ruby gem.
+      - name: Install Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ruby # Install latest version
+
       - name: Install licensed
         uses: licensee/setup-licensed@v1.3.2
         with:
@@ -119,6 +125,12 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
+
+      # This is required to allow licensee/setup-licensed to install Licensed via Ruby gem.
+      - name: Install Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ruby # Install latest version
 
       - name: Install licensed
         uses: licensee/setup-licensed@v1.3.2


### PR DESCRIPTION
The [**Licensed**](https://github.com/licensee/licensed) tool is used to check the project's compatibility with the licensing of its dependencies.

This tool is installed by the dependency license check GitHub Actions workflow using the [**licensee/setup-licensed**](https://github.com/licensee/setup-licensed) GitHub Actions action. This action attempts the installation according to the following procedure:

1. Install [the Ruby gem](https://rubygems.org/gems/licensed).
2. If gem installation fails, install the pre-built executable from the GitHub release asset in the `licensee/licensed` repo.

Previously, the first of these installation methods was failing:

```text
/usr/bin/gem install licensed -v 3.9.1
ERROR:  While executing gem ... (Gem::FilePermissionError)
    You don't have write permissions for the /var/lib/gems/3.2.0 directory.
	/usr/lib/ruby/vendor_ruby/rubygems/installer.rb:713:in `verify_gem_home'
	/usr/lib/ruby/vendor_ruby/rubygems/installer.rb:903:in `pre_install_checks'
	/usr/lib/ruby/vendor_ruby/rubygems/installer.rb:303:in `install'
	/usr/lib/ruby/vendor_ruby/rubygems/resolver/specification.rb:105:in `install'
	/usr/lib/ruby/vendor_ruby/rubygems/request_set.rb:195:in `block in install'
	/usr/lib/ruby/vendor_ruby/rubygems/request_set.rb:183:in `each'
	/usr/lib/ruby/vendor_ruby/rubygems/request_set.rb:183:in `install'
	/usr/lib/ruby/vendor_ruby/rubygems/commands/install_command.rb:215:in `install_gem'
	/usr/lib/ruby/vendor_ruby/rubygems/commands/install_command.rb:231:in `block in install_gems'
	/usr/lib/ruby/vendor_ruby/rubygems/commands/install_command.rb:224:in `each'
	/usr/lib/ruby/vendor_ruby/rubygems/commands/install_command.rb:224:in `install_gems'
	/usr/lib/ruby/vendor_ruby/rubygems/commands/install_command.rb:170:in `execute'
	/usr/lib/ruby/vendor_ruby/rubygems/command.rb:328:in `invoke_with_build_args'
	/usr/lib/ruby/vendor_ruby/rubygems/command_manager.rb:253:in `invoke_command'
	/usr/lib/ruby/vendor_ruby/rubygems/command_manager.rb:193:in `process_args'
	/usr/lib/ruby/vendor_ruby/rubygems/command_manager.rb:151:in `run'
	/usr/lib/ruby/vendor_ruby/rubygems/gem_runner.rb:52:in `run'
	/usr/bin/gem:12:in `<main>'
gem installation was not successful
```

So it falls back on the second installation method. That method works fine when using a version of **Licensed*** <4.0.0. However, [starting from version 4.0.0, pre-built executable are no longer provided](https://github.com/licensee/setup-licensed#installing-licensed-as-an-executable), so the only available installation method for modern versions of **Licensed** is via the Ruby gem.

The gem failure can be avoided by setting up an accessible installation of Ruby in the runner machine, which is accomplished using the [**ruby/setup-ruby**](https://github.com/ruby/setup-ruby) action in a step preceding the **licensee/setup-licensed** step in the workflow.
