### PR TITLE
Install referenced schema in "npm:validate" task

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -255,6 +255,10 @@ tasks:
       AVA_SCHEMA_URL: https://json.schemastore.org/ava.json
       AVA_SCHEMA_PATH:
         sh: task utility:mktemp-file TEMPLATE="ava-schema-XXXXXXXXXX.json"
+      # Source: https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/base.json
+      BASE_SCHEMA_URL: https://json.schemastore.org/base.json
+      BASE_SCHEMA_PATH:
+        sh: task utility:mktemp-file TEMPLATE="base-schema-XXXXXXXXXX.json"
       # Source: https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/eslintrc.json
       ESLINTRC_SCHEMA_URL: https://json.schemastore.org/eslintrc.json
       ESLINTRC_SCHEMA_PATH:
@@ -263,6 +267,14 @@ tasks:
       JSCPD_SCHEMA_URL: https://json.schemastore.org/jscpd.json
       JSCPD_SCHEMA_PATH:
         sh: task utility:mktemp-file TEMPLATE="jscpd-schema-XXXXXXXXXX.json"
+      # Source: https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/npm-badges.json
+      NPM_BADGES_SCHEMA_URL: https://json.schemastore.org/npm-badges.json
+      NPM_BADGES_SCHEMA_PATH:
+        sh: task utility:mktemp-file TEMPLATE="npm-badges-schema-XXXXXXXXXX.json"
+      # Source: https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/partial-eslint-plugins.json
+      PARTIAL_ESLINT_PLUGINS_SCHEMA_URL: https://json.schemastore.org/partial-eslint-plugins.json
+      PARTIAL_ESLINT_PLUGINS_PATH:
+        sh: task utility:mktemp-file TEMPLATE="partial-eslint-plugins-schema-XXXXXXXXXX.json"
       # Source: https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/prettierrc.json
       PRETTIERRC_SCHEMA_URL: https://json.schemastore.org/prettierrc.json
       PRETTIERRC_SCHEMA_PATH:
@@ -283,8 +295,11 @@ tasks:
     cmds:
       - wget --quiet --output-document="{{.SCHEMA_PATH}}" {{.SCHEMA_URL}}
       - wget --quiet --output-document="{{.AVA_SCHEMA_PATH}}" {{.AVA_SCHEMA_URL}}
+      - wget --quiet --output-document="{{.BASE_SCHEMA_PATH}}" {{.BASE_SCHEMA_URL}}
       - wget --quiet --output-document="{{.ESLINTRC_SCHEMA_PATH}}" {{.ESLINTRC_SCHEMA_URL}}
       - wget --quiet --output-document="{{.JSCPD_SCHEMA_PATH}}" {{.JSCPD_SCHEMA_URL}}
+      - wget --quiet --output-document="{{.NPM_BADGES_SCHEMA_PATH}}" {{.NPM_BADGES_SCHEMA_URL}}
+      - wget --quiet --output-document="{{.PARTIAL_ESLINT_PLUGINS_PATH}}" {{.PARTIAL_ESLINT_PLUGINS_SCHEMA_URL}}
       - wget --quiet --output-document="{{.PRETTIERRC_SCHEMA_PATH}}" {{.PRETTIERRC_SCHEMA_URL}}
       - wget --quiet --output-document="{{.SEMANTIC_RELEASE_SCHEMA_PATH}}" {{.SEMANTIC_RELEASE_SCHEMA_URL}}
       - wget --quiet --output-document="{{.STYLELINTRC_SCHEMA_PATH}}" {{.STYLELINTRC_SCHEMA_URL}}
@@ -294,8 +309,11 @@ tasks:
           --all-errors \
           -s "{{.SCHEMA_PATH}}" \
           -r "{{.AVA_SCHEMA_PATH}}" \
+          -r "{{.BASE_SCHEMA_PATH}}" \
           -r "{{.ESLINTRC_SCHEMA_PATH}}" \
           -r "{{.JSCPD_SCHEMA_PATH}}" \
+          -r "{{.NPM_BADGES_SCHEMA_PATH}}" \
+          -r "{{.PARTIAL_ESLINT_PLUGINS_PATH}}" \
           -r "{{.PRETTIERRC_SCHEMA_PATH}}" \
           -r "{{.SEMANTIC_RELEASE_SCHEMA_PATH}}" \
           -r "{{.STYLELINTRC_SCHEMA_PATH}}" \


### PR DESCRIPTION
The "npm:validate" task validates the repository's `package.json` npm manifest file against its JSON schema to catch any problems with its data format.

In order to avoid duplication of content, JSON schemas may reference other schemas via the [`$ref` keyword](https://json-schema.org/learn/getting-started-step-by-step#external). The `package.json` schema was recently updated to share resources with several other schemas, which caused the validation to start failing:

```text
schema /tmp/package-json-schema-3RnDtCIiPG.json is invalid error: can't resolve reference https://json.schemastore.org/partial-eslint-plugins.json from id https://json.schemastore.org/eslintrc.json#
```

The solution is to configure the task to download the referenced schemas and provide their paths to the avj-cli validator via `-r` flags.