### PR TITLE
Add support to "Check npm" workflow for projects in subfolders

### DIFF
--- a/.github/workflows/check-npm-task.yml
+++ b/.github/workflows/check-npm-task.yml
@@ -51,7 +51,14 @@ jobs:
         run: task --silent npm:validate
 
   check-sync:
+    name: check-sync (${{ matrix.project.path }})
     runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        project:
+          - path: .
 
     steps:
       - name: Checkout repository
@@ -69,7 +76,15 @@ jobs:
           version: 3.x
 
       - name: Install npm dependencies
-        run: task npm:install-deps
+        run: |
+          task \
+            npm:install-deps \
+            PROJECT_PATH="${{ matrix.project.path }}"
 
       - name: Check package-lock.json
-        run: git diff --color --exit-code package-lock.json
+        run: |
+          git \
+            diff \
+              --color \
+              --exit-code \
+              "${{ matrix.project.path }}/package-lock.json"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -5,6 +5,8 @@ includes:
   dist: ./DistTasks.yml
 
 vars:
+  # Path of the primary npm-managed project:
+  DEFAULT_NPM_PROJECT_PATH: ./
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/release-go-task/Taskfile.yml
   PROJECT_NAME: "arduinoOTA"
   DIST_DIR: "dist"
@@ -239,7 +241,12 @@ tasks:
 
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/npm-task/Taskfile.yml
   npm:install-deps:
-    desc: Install dependencies managed by npm
+    desc: |
+      Install dependencies managed by npm.
+      Environment variable parameters:
+      PROJECT_PATH: Path of the npm-managed project (default: {{.DEFAULT_NPM_PROJECT_PATH}}).
+    dir: |
+      "{{default .DEFAULT_NPM_PROJECT_PATH .PROJECT_PATH}}"
     cmds:
       - npm install
 


### PR DESCRIPTION
The "Check npm" workflow checks for problems with the npm configuration files of a repository. Previously this workflow assumed that a repository would only ever have these files in the root folder. However, a repository might also contain multiple separate npm-managed projects in arbitrary subfolders.

Support for any repository structure is added to the workflow by using a job matrix to check the projects under an array of arbitrary paths that can be configured for the specific repository the template is installed in.