### PR TITLE
Use project version of ajv-cli in `npm:validate` task

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -33,8 +33,6 @@ vars:
   DEFAULT_GO_PACKAGES:
     sh: |
       echo $(cd {{default .DEFAULT_GO_MODULE_PATH .GO_MODULE_PATH}} && go list ./... | tr '\n' ' ' || echo '"ERROR: Unable to discover Go packages"')
-  # Last version of ajv-cli with support for the JSON schema "Draft 4" specification
-  SCHEMA_DRAFT_4_AJV_CLI_VERSION: 3.3.0
 
 tasks:
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-workflows-task/Taskfile.yml
@@ -256,6 +254,8 @@ tasks:
       Validate npm configuration files against their JSON schema.
       Environment variable parameters:
       PROJECT_PATH: Path of the npm-managed project (default: {{.DEFAULT_NPM_PROJECT_PATH}}).
+    deps:
+      - task: npm:install-deps
     vars:
       # Source: https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/package.json
       SCHEMA_URL: https://json.schemastore.org/package.json
@@ -315,20 +315,23 @@ tasks:
       - wget --quiet --output-document="{{.SEMANTIC_RELEASE_SCHEMA_PATH}}" {{.SEMANTIC_RELEASE_SCHEMA_URL}}
       - wget --quiet --output-document="{{.STYLELINTRC_SCHEMA_PATH}}" {{.STYLELINTRC_SCHEMA_URL}}
       - |
-        cd "{{.WORKING_FOLDER}}"  # Workaround for https://github.com/npm/cli/issues/3210
-        npx ajv-cli@{{.SCHEMA_DRAFT_4_AJV_CLI_VERSION}} validate \
-          --all-errors \
-          -s "{{.SCHEMA_PATH}}" \
-          -r "{{.AVA_SCHEMA_PATH}}" \
-          -r "{{.BASE_SCHEMA_PATH}}" \
-          -r "{{.ESLINTRC_SCHEMA_PATH}}" \
-          -r "{{.JSCPD_SCHEMA_PATH}}" \
-          -r "{{.NPM_BADGES_SCHEMA_PATH}}" \
-          -r "{{.PARTIAL_ESLINT_PLUGINS_PATH}}" \
-          -r "{{.PRETTIERRC_SCHEMA_PATH}}" \
-          -r "{{.SEMANTIC_RELEASE_SCHEMA_PATH}}" \
-          -r "{{.STYLELINTRC_SCHEMA_PATH}}" \
-          -d "{{.PROJECT_FOLDER}}/{{.INSTANCE_PATH}}"
+        npx \
+          --package=ajv-cli \
+          --package=ajv-formats \
+          ajv validate \
+            --all-errors \
+            --strict=false \
+            -s "{{.SCHEMA_PATH}}" \
+            -r "{{.AVA_SCHEMA_PATH}}" \
+            -r "{{.BASE_SCHEMA_PATH}}" \
+            -r "{{.ESLINTRC_SCHEMA_PATH}}" \
+            -r "{{.JSCPD_SCHEMA_PATH}}" \
+            -r "{{.NPM_BADGES_SCHEMA_PATH}}" \
+            -r "{{.PARTIAL_ESLINT_PLUGINS_PATH}}" \
+            -r "{{.PRETTIERRC_SCHEMA_PATH}}" \
+            -r "{{.SEMANTIC_RELEASE_SCHEMA_PATH}}" \
+            -r "{{.STYLELINTRC_SCHEMA_PATH}}" \
+            -d "{{.INSTANCE_PATH}}"
 
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/poetry-task/Taskfile.yml
   poetry:install-deps:


### PR DESCRIPTION
The [**ajv-cli** command line tool](https://github.com/ajv-validator/ajv-cli) is used for validating data files against their [JSON schema](https://json-schema.org/).

In general, it is preferable, and for some schemas even mandatory, to use the modern versions of ajv-cli. However, support for the ["Draft-04" schema specification](https://json-schema.org/specification-links.html#draft-4) schema specification was dropped in ajv-cli version 4.0.0. So when working with JSON schemas that specify that draft, it is necessary to use **ajv-cli** 3.3.0, the last compatible version.

Previously, the `package.json` schema specified the "Draft-04" specification. For this reason, the `npm:validate` task was configured to use ajv-cli@3.3.0.

The `package.json` schema has now been updated to use "Draft-07" (https://github.com/SchemaStore/schemastore/commit/11e62f6fde72bab69d31a5d4274fd20e08a7d87f). So the code for using ajv-cli@3.3.0 is removed from the task, and the standard project level version of **ajv-cli** will now be used by this task.