### PR TITLE
Use engines.node as source of version data for "actions/setup-node" action

### DIFF
--- a/.github/workflows/check-markdown-task.yml
+++ b/.github/workflows/check-markdown-task.yml
@@ -1,10 +1,6 @@
 # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/check-markdown-task.md
 name: Check Markdown
 
-env:
-  # See: https://github.com/actions/setup-node/#readme
-  NODE_VERSION: 16.x
-
 # See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows
 on:
   create:
@@ -74,7 +70,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ env.NODE_VERSION }}
+          node-version-file: package.json
 
       - name: Initialize markdownlint-cli problem matcher
         uses: xt0rted/markdownlint-problem-matcher@v3
@@ -100,7 +96,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ env.NODE_VERSION }}
+          node-version-file: package.json
 
       - name: Install Task
         uses: arduino/setup-task@v2

--- a/.github/workflows/check-npm-task.yml
+++ b/.github/workflows/check-npm-task.yml
@@ -1,10 +1,6 @@
 # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/check-npm-task.md
 name: Check npm
 
-env:
-  # See: https://github.com/actions/setup-node/#readme
-  NODE_VERSION: 16.x
-
 # See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows
 on:
   push:
@@ -46,7 +42,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ env.NODE_VERSION }}
+          node-version-file: package.json
 
       - name: Install Task
         uses: arduino/setup-task@v2
@@ -78,7 +74,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ env.NODE_VERSION }}
+          node-version-file: package.json
 
       - name: Install Task
         uses: arduino/setup-task@v2

--- a/.github/workflows/check-prettier-formatting-task.yml
+++ b/.github/workflows/check-prettier-formatting-task.yml
@@ -1,10 +1,6 @@
 # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/check-prettier-formatting-task.md
 name: Check Prettier Formatting
 
-env:
-  # See: https://github.com/actions/setup-node/#readme
-  NODE_VERSION: 16.x
-
 # See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows
 on:
   push:
@@ -216,7 +212,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ env.NODE_VERSION }}
+          node-version-file: package.json
 
       - name: Install Task
         uses: arduino/setup-task@v2

--- a/.github/workflows/check-taskfiles.yml
+++ b/.github/workflows/check-taskfiles.yml
@@ -1,10 +1,6 @@
 # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/check-taskfiles.md
 name: Check Taskfiles
 
-env:
-  # See: https://github.com/actions/setup-node/#readme
-  NODE_VERSION: 16.x
-
 # See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows
 on:
   push:
@@ -48,7 +44,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ env.NODE_VERSION }}
+          node-version-file: package.json
 
       - name: Download JSON schema for Taskfiles
         id: download-schema

--- a/.github/workflows/check-workflows-task.yml
+++ b/.github/workflows/check-workflows-task.yml
@@ -1,10 +1,6 @@
 # Source: https://github.com/arduino/tooling-project-assets/blob/master/workflow-templates/check-workflows-task.md
 name: Check Workflows
 
-env:
-  # See: https://github.com/actions/setup-node/#readme
-  NODE_VERSION: 16.x
-
 # See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows
 on:
   push:
@@ -36,7 +32,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ env.NODE_VERSION }}
+          node-version-file: package.json
 
       - name: Install Task
         uses: arduino/setup-task@v2

--- a/.github/workflows/sync-labels-npm.yml
+++ b/.github/workflows/sync-labels-npm.yml
@@ -2,8 +2,6 @@
 name: Sync Labels
 
 env:
-  # See: https://github.com/actions/setup-node/#readme
-  NODE_VERSION: 16.x
   CONFIGURATIONS_FOLDER: .github/label-configuration-files
   CONFIGURATIONS_ARTIFACT_PREFIX: label-configuration-file-
 
@@ -38,7 +36,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ env.NODE_VERSION }}
+          node-version-file: package.json
 
       - name: Download JSON schema for labels configuration file
         id: download-schema
@@ -133,7 +131,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ env.NODE_VERSION }}
+          node-version-file: package.json
 
       - name: Merge label configuration files
         run: |

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -299,10 +299,6 @@ tasks:
         sh: task utility:mktemp-file TEMPLATE="stylelintrc-schema-XXXXXXXXXX.json"
       INSTANCE_PATH: >-
         {{default .DEFAULT_NPM_PROJECT_PATH .PROJECT_PATH}}/package.json
-      PROJECT_FOLDER:
-        sh: pwd
-      WORKING_FOLDER:
-        sh: task utility:mktemp-folder TEMPLATE="dependabot-validate-XXXXXXXXXX"
     cmds:
       - wget --quiet --output-document="{{.SCHEMA_PATH}}" {{.SCHEMA_URL}}
       - wget --quiet --output-document="{{.AVA_SCHEMA_PATH}}" {{.AVA_SCHEMA_URL}}

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,9 @@
         "markdown-link-check": "^3.13.7",
         "markdownlint-cli": "^0.37.0",
         "prettier": "^3.5.3"
+      },
+      "engines": {
+        "node": "16.x"
       }
     },
     "node_modules/@financial-times/origami-service-makefile": {

--- a/package.json
+++ b/package.json
@@ -6,5 +6,8 @@
     "markdown-link-check": "^3.13.7",
     "markdownlint-cli": "^0.37.0",
     "prettier": "^3.5.3"
+  },
+  "engines": {
+    "node": "16.x"
   }
 }


### PR DESCRIPTION
A single standardized version of Node.js is used for all development work in this repository, both by contributors and the automated validation systems.

The **actions/setup-node** GitHub Actions action is used to set up Node.js in the GitHub Actions runner machine.

The action supports obtaining the Node.js version to set up from the `engines.node` field of the `package.json` file:

https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#node-version-file

This allows us to define the standardized version of Node.js for use by project contributors in a single place rather than having to maintain multiple instances of that data.
