### PR TITLE
Configure npm to enforce standard project Node.js version

### DIFF
--- a/.github/workflows/check-markdown-task.yml
+++ b/.github/workflows/check-markdown-task.yml
@@ -16,6 +16,7 @@ on:
       - "**.mkdn"
       - "**.mdown"
       - "**.markdown"
+      - "**/.npmrc"
   pull_request:
     paths:
       - ".github/workflows/check-markdown-task.ya?ml"
@@ -28,6 +29,7 @@ on:
       - "**.mkdn"
       - "**.mdown"
       - "**.markdown"
+      - "**/.npmrc"
   schedule:
     # Run every Tuesday at 8 AM UTC to catch breakage caused by external changes.
     - cron: "0 8 * * TUE"

--- a/.github/workflows/check-npm-task.yml
+++ b/.github/workflows/check-npm-task.yml
@@ -6,12 +6,14 @@ on:
   push:
     paths:
       - ".github/workflows/check-npm-task.ya?ml"
+      - "**/.npmrc"
       - "**/package.json"
       - "**/package-lock.json"
       - "Taskfile.ya?ml"
   pull_request:
     paths:
       - ".github/workflows/check-npm-task.ya?ml"
+      - "**/.npmrc"
       - "**/package.json"
       - "**/package-lock.json"
       - "Taskfile.ya?ml"

--- a/.github/workflows/check-prettier-formatting-task.yml
+++ b/.github/workflows/check-prettier-formatting-task.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - ".github/workflows/check-prettier-formatting-task.ya?ml"
       - "Taskfile.ya?ml"
+      - "**/.npmrc"
       - "**/.prettierignore"
       - "**/.prettierrc*"
       # CSS
@@ -103,6 +104,7 @@ on:
     paths:
       - ".github/workflows/check-prettier-formatting-task.ya?ml"
       - "Taskfile.ya?ml"
+      - "**/.npmrc"
       - "**/.prettierignore"
       - "**/.prettierrc*"
       # CSS

--- a/.github/workflows/check-taskfiles.yml
+++ b/.github/workflows/check-taskfiles.yml
@@ -8,6 +8,7 @@ on:
       - ".github/workflows/check-taskfiles.ya?ml"
       - "package.json"
       - "package-lock.json"
+      - "**/.npmrc"
       - "**/Taskfile.ya?ml"
       - "**/DistTasks.ya?ml"
   pull_request:
@@ -15,6 +16,7 @@ on:
       - ".github/workflows/check-taskfiles.ya?ml"
       - "package.json"
       - "package-lock.json"
+      - "**/.npmrc"
       - "**/Taskfile.ya?ml"
       - "**/DistTasks.ya?ml"
   schedule:

--- a/.github/workflows/check-workflows-task.yml
+++ b/.github/workflows/check-workflows-task.yml
@@ -9,12 +9,14 @@ on:
       - "package.json"
       - "package-lock.json"
       - "Taskfile.ya?ml"
+      - "**/.npmrc"
   pull_request:
     paths:
       - ".github/workflows/*.ya?ml"
       - "package.json"
       - "package-lock.json"
       - "Taskfile.ya?ml"
+      - "**/.npmrc"
   schedule:
     # Run every Tuesday at 8 AM UTC to catch breakage resulting from changes to the JSON schema.
     - cron: "0 8 * * TUE"

--- a/.github/workflows/sync-labels-npm.yml
+++ b/.github/workflows/sync-labels-npm.yml
@@ -13,12 +13,14 @@ on:
       - ".github/label-configuration-files/*.ya?ml"
       - "package.json"
       - "package-lock.json"
+      - "**/.npmrc"
   pull_request:
     paths:
       - ".github/workflows/sync-labels-npm.ya?ml"
       - ".github/label-configuration-files/*.ya?ml"
       - "package.json"
       - "package-lock.json"
+      - "**/.npmrc"
   schedule:
     # Run daily at 8 AM UTC to sync with changes to shared label configurations.
     - cron: "0 8 * * *"

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,3 @@
+# See: https://docs.npmjs.com/cli/configuring-npm/npmrc
+
+engine-strict = true


### PR DESCRIPTION
This will produce an error if a contributor attempts to run an npm command in the project using an unsupported version of Node.js.