### PR TITLE
Split infrastructure shell commands into multiple lines for readability

### DIFF
--- a/.github/workflows/check-general-formatting-task.yml
+++ b/.github/workflows/check-general-formatting-task.yml
@@ -71,12 +71,19 @@ jobs:
       - name: Install editorconfig-checker
         run: |
           cd "${{ env.EC_INSTALL_PATH }}"
-          tar --extract --file="${{ steps.download.outputs.name }}"
+          tar \
+            --extract \
+            --file="${{ steps.download.outputs.name }}"
           # Give the binary a standard name
-          mv "${{ env.EC_INSTALL_PATH }}/bin/ec-linux-amd64" "${{ env.EC_INSTALL_PATH }}/bin/ec"
+          mv \
+            "${{ env.EC_INSTALL_PATH }}/bin/ec-linux-amd64" \
+            "${{ env.EC_INSTALL_PATH }}/bin/ec"
           # Add installation to PATH:
           # See: https://docs.github.com/actions/using-workflows/workflow-commands-for-github-actions#adding-a-system-path
           echo "${{ env.EC_INSTALL_PATH }}/bin" >> "$GITHUB_PATH"
 
       - name: Check formatting
-        run: task --silent general:check-formatting
+        run: |
+          task \
+            --silent \
+            general:check-formatting

--- a/.github/workflows/check-go-dependencies-task.yml
+++ b/.github/workflows/check-go-dependencies-task.yml
@@ -155,4 +155,7 @@ jobs:
           version: 3.x
 
       - name: Check for dependencies with unapproved licenses
-        run: task --silent general:check-dep-licenses
+        run: |
+          task \
+            --silent \
+            general:check-dep-licenses

--- a/.github/workflows/check-go-task.yml
+++ b/.github/workflows/check-go-task.yml
@@ -124,7 +124,11 @@ jobs:
         run: task go:fix
 
       - name: Check if any fixes were needed
-        run: git diff --color --exit-code
+        run: |
+          git \
+            diff \
+              --color \
+              --exit-code
 
   check-style:
     name: check-style (${{ matrix.module.path }})
@@ -200,7 +204,11 @@ jobs:
         run: task go:format
 
       - name: Check formatting
-        run: git diff --color --exit-code
+        run: |
+          git \
+            diff \
+              --color \
+              --exit-code
 
   check-config:
     name: check-config (${{ matrix.module.path }})
@@ -231,4 +239,8 @@ jobs:
         run: go mod tidy
 
       - name: Check whether any tidying was needed
-        run: git diff --color --exit-code
+        run: |
+          git \
+            diff \
+              --color \
+              --exit-code

--- a/.github/workflows/check-markdown-task.yml
+++ b/.github/workflows/check-markdown-task.yml
@@ -112,4 +112,7 @@ jobs:
           version: 3.x
 
       - name: Check links
-        run: task --silent markdown:check-links
+        run: |
+          task \
+            --silent \
+            markdown:check-links

--- a/.github/workflows/check-prettier-formatting-task.yml
+++ b/.github/workflows/check-prettier-formatting-task.yml
@@ -252,7 +252,13 @@ jobs:
           version: 3.x
 
       - name: Format with Prettier
-        run: task general:format-prettier
+        run: |
+          task \
+            general:format-prettier
 
       - name: Check formatting
-        run: git diff --color --exit-code
+        run: |
+          git \
+            diff \
+              --color \
+              --exit-code

--- a/.github/workflows/check-workflows-task.yml
+++ b/.github/workflows/check-workflows-task.yml
@@ -45,4 +45,7 @@ jobs:
           version: 3.x
 
       - name: Validate workflows
-        run: task --silent ci:validate
+        run: |
+          task \
+            --silent \
+            ci:validate

--- a/.github/workflows/check-yaml-task.yml
+++ b/.github/workflows/check-yaml-task.yml
@@ -114,4 +114,7 @@ jobs:
 
       - name: Check YAML
         continue-on-error: ${{ matrix.configuration.continue-on-error }}
-        run: task yaml:lint YAMLLINT_FORMAT=${{ matrix.configuration.format }}
+        run: |
+          task \
+            yaml:lint \
+            YAMLLINT_FORMAT=${{ matrix.configuration.format }}

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -74,7 +74,8 @@ tasks:
     cmds:
       - |
         if ! which ec &>/dev/null; then
-          echo "ec not found or not in PATH. Please install: https://github.com/editorconfig-checker/editorconfig-checker#installation"
+          echo "ec not found or not in PATH."
+          echo "Please install: https://github.com/editorconfig-checker/editorconfig-checker#installation"
           exit 1
         fi
       - ec
@@ -85,7 +86,11 @@ tasks:
     deps:
       - task: npm:install-deps
     cmds:
-      - npx prettier --write .
+      - |
+        npx \
+          prettier \
+            --write \
+            .
 
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-dependencies-task/Taskfile.yml
   general:cache-dep-licenses:
@@ -97,7 +102,8 @@ tasks:
             echo "Licensed does not have Windows support."
             echo "Please use Linux/macOS or download the dependencies cache from the GitHub Actions workflow artifact."
           else
-            echo "licensed not found or not in PATH. Please install: https://github.com/github/licensed#as-an-executable"
+            echo "licensed not found or not in PATH."
+            echo "Please install: https://github.com/github/licensed#as-an-executable"
           fi
           exit 1
         fi
@@ -117,7 +123,9 @@ tasks:
     deps:
       - task: poetry:install-deps
     cmds:
-      - poetry run codespell
+      - |
+        poetry run \
+          codespell
 
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/spell-check-task/Taskfile.yml
   general:correct-spelling:
@@ -125,7 +133,10 @@ tasks:
     deps:
       - task: poetry:install-deps
     cmds:
-      - poetry run codespell --write-changes
+      - |
+        poetry run \
+          codespell \
+            --write-changes
 
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-go-task/Taskfile.yml
   go:fix:
@@ -227,7 +238,11 @@ tasks:
     deps:
       - task: npm:install-deps
     cmds:
-      - npx markdownlint-cli --fix "**/*.md"
+      - |
+        npx \
+          markdownlint-cli \
+            --fix \
+            "**/*.md"
 
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-markdown-task/Taskfile.yml
   markdown:lint:
@@ -235,7 +250,10 @@ tasks:
     deps:
       - task: npm:install-deps
     cmds:
-      - npx markdownlint-cli "**/*.md"
+      - |
+        npx \
+          markdownlint-cli \
+          "**/*.md"
 
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/npm-task/Taskfile.yml
   npm:install-deps:
@@ -376,4 +394,9 @@ tasks:
     deps:
       - task: poetry:install-deps
     cmds:
-      - poetry run yamllint --format {{default "colored" .YAMLLINT_FORMAT}} .
+      - |
+        poetry run \
+          yamllint \
+            --format \
+            {{default "colored" .YAMLLINT_FORMAT}} \
+            .


### PR DESCRIPTION
The project's GitHub Actions workflows and tasks contain complex shell command lines.

With the use of the line continuation operator, these commands can be split into multiple code lines. This improves readability by providing a visualization of the command structure. It also improves maintainability by making diffs for changes to these commands more clear.