### PR TITLE
Use `go.mod` as source of Go version number for workflows

### DIFF
--- a/.github/workflows/check-go-dependencies-task.yml
+++ b/.github/workflows/check-go-dependencies-task.yml
@@ -1,10 +1,6 @@
 # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/check-go-dependencies-task.md
 name: Check Go Dependencies
 
-env:
-  # See: https://github.com/actions/setup-go/tree/main#supported-version-syntax
-  GO_VERSION: "1.17"
-
 # See: https://docs.github.com/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows
 on:
   create:
@@ -87,7 +83,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
 
       - name: Install Task
         uses: arduino/setup-task@v2
@@ -146,7 +142,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
 
       - name: Install Task
         uses: arduino/setup-task@v2

--- a/.github/workflows/check-go-task.yml
+++ b/.github/workflows/check-go-task.yml
@@ -1,10 +1,6 @@
 # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/check-go-task.md
 name: Check Go
 
-env:
-  # See: https://github.com/actions/setup-go/tree/main#supported-version-syntax
-  GO_VERSION: "1.17"
-
 # See: https://docs.github.com/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows
 on:
   create:
@@ -75,7 +71,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: ${{ matrix.module.path }}/go.mod
 
       - name: Install Task
         uses: arduino/setup-task@v2
@@ -110,7 +106,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: ${{ matrix.module.path }}/go.mod
 
       - name: Install Task
         uses: arduino/setup-task@v2
@@ -152,7 +148,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: ${{ matrix.module.path }}/go.mod
 
       - name: Install Task
         uses: arduino/setup-task@v2
@@ -190,7 +186,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: ${{ matrix.module.path }}/go.mod
 
       - name: Install Task
         uses: arduino/setup-task@v2
@@ -223,7 +219,7 @@ jobs:
 
       matrix:
         module:
-          - path: ./
+          - path: .
 
     steps:
       - name: Checkout repository
@@ -232,7 +228,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: ${{ matrix.module.path }}/go.mod
 
       - name: Run go mod tidy
         working-directory: ${{ matrix.module.path }}

--- a/.github/workflows/release-go-crosscompile-task.yml
+++ b/.github/workflows/release-go-crosscompile-task.yml
@@ -1,6 +1,11 @@
 # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/release-go-crosscompile-task.md
 name: Release
 
+on:
+  push:
+    tags:
+      - "[0-9]+.[0-9]+.[0-9]+*"
+
 env:
   # As defined by the Taskfile's PROJECT_NAME variable
   PROJECT_NAME: arduinoOTA
@@ -9,13 +14,6 @@ env:
   # The project's folder on Arduino's download server for uploading builds
   AWS_PLUGIN_TARGET: /arduinoOTA/
   ARTIFACT_PREFIX: dist-
-  # See: https://github.com/actions/setup-go/tree/main#supported-version-syntax
-  GO_VERSION: "1.17"
-
-on:
-  push:
-    tags:
-      - "[0-9]+.[0-9]+.[0-9]+*"
 
 jobs:
   create-release-artifacts:
@@ -64,7 +62,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
 
       - name: Install Task
         uses: arduino/setup-task@v2


### PR DESCRIPTION
Go is used in the development and maintenance of the project. A standardized version of Go is used for all operations.

This version is defined in the [`go` directive](https://go.dev/ref/mod#go-mod-file-go) of the `go.mod` metadata file.

Go is installed in the GitHub Actions runner environments using the **actions/setup-go** action, which also must be configured to install the correct version of Go. Previously the version number for use by the **actions/setup-go** action was defined in each workflow. This meant that we had multiple copies of the Go version information, all of which had to be kept in sync.

Fortunately, support for using `go.mod` as the source of version information for the **actions/setup-go** action was recently added:

https://github.com/actions/setup-go/tree/main#getting-go-version-from-the-gomod-file

This means it is now possible for all workflows to get the Go version from a single source.