### PR TITLE
Add reference link comment for Prettier filename matching patterns

### DIFF
--- a/.github/workflows/check-prettier-formatting-task.yml
+++ b/.github/workflows/check-prettier-formatting-task.yml
@@ -11,6 +11,8 @@ on:
       - "**/.npmrc"
       - "**/.prettierignore"
       - "**/.prettierrc*"
+      # Prettier-covered file patterns are defined by:
+      # https://github.com/github-linguist/linguist/blob/main/lib/linguist/languages.yml
       # CSS
       - "**.css"
       - "**.wxss"


### PR DESCRIPTION
[**Prettier**](https://prettier.io/) uses filename pattern matching to identify the programming language of files (and from this determines which files to format, and how to format those files). This is based on data from the [**Linguist**](https://github.com/github-linguist/linguist) project.

That data was used as a reference for configuring the paths filter of the "Check Prettier Formatting" workflow, which ensures that the workflow will run whenever relevant files are modified.

Documenting that reference via a comment in the workflow will facilitate the maintenance of the paths filter.