### PR TITLE
Remove superfluous "TODO" comment

### DIFF
--- a/.github/workflows/check-taskfiles.yml
+++ b/.github/workflows/check-taskfiles.yml
@@ -64,7 +64,6 @@ jobs:
 
       matrix:
         file:
-          # TODO: add paths to any additional Taskfiles here
           - ./**/Taskfile.yml
           - ./**/DistTasks.yml
 


### PR DESCRIPTION
This repository's infrastructure is based on [a collection of reusable "template" assets](https://github.com/arduino/tooling-project-assets). In cases where those assets must be configured for the specific project in which they are used, this is indicated by a "TODO" comment.

Once the configuration indicated by the "TODO" comment is made, the comment should be removed as it no longer serves any purpose. One of these comments was not removed at the time the asset was installed.