### PR TITLE
Use `pyproject.toml` as Python version source

### DIFF
--- a/.github/workflows/check-yaml-task.yml
+++ b/.github/workflows/check-yaml-task.yml
@@ -101,7 +101,7 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ env.PYTHON_VERSION }}
+          python-version-file: pyproject.toml
 
       - name: Install Poetry
         run: pip install poetry

--- a/.github/workflows/spell-check-task.yml
+++ b/.github/workflows/spell-check-task.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ env.PYTHON_VERSION }}
+          python-version-file: pyproject.toml
 
       - name: Install Poetry
         run: pip install poetry

--- a/poetry.lock
+++ b/poetry.lock
@@ -90,5 +90,5 @@ dev = ["doc8", "flake8", "flake8-import-order", "rstcheck[sphinx]", "sphinx"]
 
 [metadata]
 lock-version = "2.1"
-python-versions = "^3.9"
-content-hash = "da8be4c90085fa15fedd5bb0e4ee4dccb4ffb0cf940408eded81687725fa5d18"
+python-versions = "~3.9"
+content-hash = "37fd99b9473823b2fac53ff63add91780c55e5a808238623237aba46c8d58f58"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = ""
 authors = []
 
 [tool.poetry.dependencies]
-python = "^3.9"
+python = "~3.9"
 
 [tool.poetry.dev-dependencies]
 yamllint = "^1.36.0"


### PR DESCRIPTION
Python and Python-based tools are used in the development and maintenance of the project. A standardized version of Python is used for these operations.

Poetry is used for Python package dependencies management. Poetry installs dependencies into a virtual environment. For this reason, the Poetry configuration includes a Python version number, which must match the correct version of Python for the project. This configuration is stored in the [`pyproject.toml` file](https://python-poetry.org/docs/pyproject/).

Python is installed in the GitHub Actions runner environments using the **actions/setup-python** action, which also must be configured to install the correct version of Python. Previously the version number for use by the actions/setup-python action was defined in each workflow. This meant that we had multiple copies of the Python version information, all of which had to be kept in sync.

Fortunately, support for using `pyproject.toml` as the source of version information for the **actions/setup-python** action was recently added (https://github.com/actions/setup-python/commit/0d5da6a89a3aa5b4dbd48e38b0c9d678b0caa0e5). This means it is now possible for all components of the project infrastructure to get the Python version from a single source.