### PR TITLE
Only install Python package dependencies from relevant group

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -122,6 +122,8 @@ tasks:
     desc: Check for commonly misspelled words
     deps:
       - task: poetry:install-deps
+        vars:
+          POETRY_GROUPS: dev
     cmds:
       - |
         poetry run \
@@ -132,6 +134,8 @@ tasks:
     desc: Correct commonly misspelled words where possible
     deps:
       - task: poetry:install-deps
+        vars:
+          POETRY_GROUPS: dev
     cmds:
       - |
         poetry run \
@@ -380,11 +384,17 @@ tasks:
 
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/poetry-task/Taskfile.yml
   poetry:install-deps:
-    desc: Install dependencies managed by Poetry
+    desc: |
+      Install dependencies managed by Poetry.
+      Environment variable parameters:
+      POETRY_GROUPS: Poetry dependency groups to install (default: install all dependencies).
     deps:
       - task: poetry:install
     cmds:
-      - poetry install --no-root
+      - |
+        poetry install \
+           --no-root \
+          {{if .POETRY_GROUPS}} --only {{.POETRY_GROUPS}} {{end}}
 
   # Make a temporary file named according to the passed TEMPLATE variable and print the path passed to stdout
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/windows-task/Taskfile.yml
@@ -426,6 +436,8 @@ tasks:
     desc: Check for problems with YAML files
     deps:
       - task: poetry:install-deps
+        vars:
+          POETRY_GROUPS: dev
     cmds:
       - |
         poetry run \


### PR DESCRIPTION
The [**Poetry**](https://python-poetry.org/) tool is used to manage the project's Python package dependencies.

Dependencies might be classified into distinct categories. The most basic classification would be:

- **Application dependencies**: used by the project's applications
- **Development dependencies**: tools used in the development and maintenance of the project, but not by the application

By default, **Poetry** installs all non-optional dependencies. This can be inefficient in a case where a specific operation is being performed, since a given operation might only require the dependencies from one category and so the installation of dependencies from the other is pointless for that operation.

For this reason, **Poetry** allows the user to organize dependencies into arbitrary "groups", and to specify which groups should be installed:

https://python-poetry.org/docs/managing-dependencies/#dependency-groups

The Python package installation task is hereby updated to allow dependency groups to be specified, and the calls to that task updated to specify the groups they require.