### PR TITLE
Add support for dependencies preparation to `general:cache-dep-licenses` task

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -95,6 +95,8 @@ tasks:
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-dependencies-task/Taskfile.yml
   general:cache-dep-licenses:
     desc: Cache dependency license metadata
+    deps:
+      - task: general:prepare-deps
     cmds:
       - |
         if ! which licensed &>/dev/null; then
@@ -141,6 +143,11 @@ tasks:
         poetry run \
           codespell \
             --write-changes
+
+  # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-go-dependencies-task/Taskfile.yml
+  general:prepare-deps:
+    desc: Prepare project dependencies for license check
+    # No preparation is needed for Go module-based projects.
 
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-go-task/Taskfile.yml
   go:fix:


### PR DESCRIPTION
The `general:cache-dep-licenses` task is used to generate metadata about the licenses of the project's dependencies.

When using some dependency management systems, it is necessary to run an operation via the dependency management tool prior to generating the metadata. Since this task is a standardized "asset" which is intended to be usable with any project, a call to a `general:prepare-deps` task was added to the `general:cache-dep-licenses` task in order to allow it to be used with such project types.

The operation required by the specific dependencies management system in use is performed in the `general:prepare-deps` task. It happens that such a preparatory operation is not necessary with the Go modules dependency management system, so an empty task is provided for use in Go module-based projects.

Since this project is Go module-based, the change is not essential. However, it is best to keep the asset in sync with the upstream copy to facilitate maintenance of the project infrastructure.