### PR TITLE
Use more efficient release artifact replacement approach

### DIFF
--- a/.github/workflows/release-go-crosscompile-task.yml
+++ b/.github/workflows/release-go-crosscompile-task.yml
@@ -120,11 +120,6 @@ jobs:
           name: ${{ env.ARTIFACT_PREFIX }}${{ matrix.build.artifact-suffix }}
           path: ${{ env.DIST_DIR }}
 
-      - name: Remove non-notarized artifact
-        uses: geekyeggo/delete-artifact@v5
-        with:
-          name: ${{ env.ARTIFACT_PREFIX }}${{ matrix.build.artifact-suffix }}
-
       - name: Import Code-Signing Certificates
         env:
           KEYCHAIN: "sign.keychain"
@@ -190,11 +185,12 @@ jobs:
           chmod +x "${{ env.BUILD_FOLDER }}/${{ env.PROJECT_NAME }}"
           tar -czvf "${{ env.PACKAGE_FILENAME }}" "${{ env.BUILD_FOLDER }}/"
 
-      - name: Upload notarized artifact
+      - name: Replace artifact with notarized build
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: error
           name: ${{ env.ARTIFACT_PREFIX }}${{ matrix.build.artifact-suffix }}
+          overwrite: true
           path: ${{ env.DIST_DIR }}/${{ env.PACKAGE_FILENAME }}
 
   create-release:


### PR DESCRIPTION
The "Release" GitHub Actions workflow automatically generates releases of the project. This is done for a range of host architectures, including macOS. The macOS builds are then put through a notarization process in a dedicated workflow job.

The builds are transferred between jobs by GitHub Actions workflow artifacts. The "create-release-artifacts" job produces macOS workflow artifacts containing non-notarized builds, which must then be replaced after the builds are notarized by the "notarize-macos" job.

Previously, the approach chosen to accomplish this replacement was to use the community created "geekyeggo/delete-artifact" action to delete each artifact after it had been downloaded by the "notarize-macos" job, then replacing it by uploading the notarized version using the "actions/upload-artifact" action.

The ability to overwrite workflows was recently added to the "actions/upload-artifact" action (https://github.com/actions/upload-artifact/commit/11ff42c7b1b52130283d8a02bc960d1e1de95000). This behavior is enabled by setting the action's `overwrite` input to `true`. By using this feature, we avoid the need to delete the artifact and thus the dependence on the "geekyeggo/delete-artifact" action is avoided, making the workflow more simple, easier to maintain, and more secure.