### PR TITLE
Remove unused job outputs from release workflow

### DIFF
--- a/.github/workflows/release-go-crosscompile-task.yml
+++ b/.github/workflows/release-go-crosscompile-task.yml
@@ -84,9 +84,6 @@ jobs:
     name: Notarize ${{ matrix.build.artifact-suffix }}
     runs-on: macos-latest
     needs: create-release-artifacts
-    outputs:
-      checksum-darwin_amd64: ${{ steps.re-package.outputs.checksum-darwin_amd64 }}
-      checksum-darwin_arm64: ${{ steps.re-package.outputs.checksum-darwin_arm64 }}
     permissions:
       contents: read
 


### PR DESCRIPTION
In a previous revision of the release workflow, the updated checksums were determined by the macOS notarization job and then passed to the subsequent job via job outputs. That approach was changed during a later refactoring (https://github.com/arduino/tooling-project-assets/pull/277, https://github.com/arduino/tooling-project-assets/pull/326), but the code that declares the job outputs was not removed at that time.

The checksum job output declaration code is now unused (and unusable since the checksum determination and output definitions were removed) so it only makes the workflow more difficult to understand and maintain. For this reason, the vestigial code is hereby removed from the workflow.