### PR TITLE
Remove unused step ID from release workflow

### DIFF
--- a/.github/workflows/release-go-crosscompile-task.yml
+++ b/.github/workflows/release-go-crosscompile-task.yml
@@ -173,7 +173,6 @@ jobs:
           gon "${{ env.GON_CONFIG_PATH }}"
 
       - name: Re-package binary
-        id: re-package
         working-directory: ${{ env.DIST_DIR }}
         # Repackage the signed binary replaced in place by Gon (ignoring the output zip file)
         run: |


### PR DESCRIPTION
In a previous revision of the release workflow, the updated checksums were determined by the macOS notarization job and then passed to the subsequent job via job outputs. Those job outputs in turn referenced step outputs, which required an ID be assigned to the step. That approach was changed during a later refactoring (https://github.com/arduino/arduinoOTA/pull/152, https://github.com/arduino/tooling-project-assets/pull/277, https://github.com/arduino/tooling-project-assets/pull/326), but the step ID definitions were not removed at that time.

The unused step IDs now only make the workflow more difficult to understand and maintain. For this reason, the vestigial code is hereby removed from the workflow.