### PR TITLE
Fix non-standard formatting of GitHub Actions context reference

### DIFF
--- a/.github/workflows/release-go-crosscompile-task.yml
+++ b/.github/workflows/release-go-crosscompile-task.yml
@@ -204,7 +204,7 @@ jobs:
           pattern: ${{ env.ARTIFACT_PREFIX }}*
 
       - name: Create checksum file
-        working-directory: ${{ env.DIST_DIR}}
+        working-directory: ${{ env.DIST_DIR }}
         run: |
           TAG="${GITHUB_REF/refs\/tags\//}"
           sha256sum ${{ env.PROJECT_NAME }}_${TAG}* > ${TAG}-checksums.txt


### PR DESCRIPTION
The established convention is to pad the GitHub Actions context identifier in references.

In this workflow code, the right hand padding was missing.