### PR TITLE
Remove unused task

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -392,17 +392,6 @@ tasks:
         vars:
           RAW_PATH: "{{.RAW_PATH}}"
 
-  # Make a temporary folder named according to the passed TEMPLATE variable and print the path passed to stdout
-  # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/windows-task/Taskfile.yml
-  utility:mktemp-folder:
-    vars:
-      RAW_PATH:
-        sh: mktemp --directory --tmpdir "{{.TEMPLATE}}"
-    cmds:
-      - task: utility:normalize-path
-        vars:
-          RAW_PATH: "{{.RAW_PATH}}"
-
   # Print a normalized version of the path passed via the RAW_PATH variable to stdout
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/windows-task/Taskfile.yml
   utility:normalize-path:


### PR DESCRIPTION
Previously, the `npm:validate` task called the `utility:mktemp-folder` task. That call was eliminated through some recent refactoring (https://github.com/arduino/arduinoOTA/pull/123), but the now `utility:mktemp-folder` task was not removed at that time.

The unused task serves no purpose and only makes the taskfile more difficult to understand and maintain. So the unused task is hereby removed.