### PR TITLE
Configure task dependencies to avoid redundant execution

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -95,6 +95,7 @@ tasks:
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-dependencies-task/Taskfile.yml
   general:cache-dep-licenses:
     desc: Cache dependency license metadata
+    run: when_changed
     deps:
       - task: general:prepare-deps
     cmds:
@@ -147,6 +148,7 @@ tasks:
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-go-dependencies-task/Taskfile.yml
   general:prepare-deps:
     desc: Prepare project dependencies for license check
+    run: when_changed
     # No preparation is needed for Go module-based projects.
 
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-go-task/Taskfile.yml
@@ -253,6 +255,7 @@ tasks:
       PROJECT_PATH: Path of the npm-managed project (default: {{.DEFAULT_NPM_PROJECT_PATH}}).
     dir: |
       "{{default .DEFAULT_NPM_PROJECT_PATH .PROJECT_PATH}}"
+    run: when_changed
     cmds:
       - npm install
 
@@ -374,6 +377,7 @@ tasks:
       Install dependencies managed by Poetry.
       Environment variable parameters:
       POETRY_GROUPS: Poetry dependency groups to install (default: install all dependencies).
+    run: when_changed
     deps:
       - task: poetry:install
     cmds:


### PR DESCRIPTION
The [**Task** task runner tool](https://taskfile.dev/) is used to perform common development operations for this project.

[Tasks may call other tasks](https://taskfile.dev/usage/#calling-another-task). Under certain conditions (most commonly when running a convenience "umbrella" which calls all tasks of a general type), this can result in the same task being called redundantly, which is inefficient. Worse, since task calls specified via [the `deps` mapping](https://taskfile.dev/usage/#task-dependencies) of a task definition are executed concurrently, the multiple executions can conflict with each other and cause problems such as a spurious failure.

This can be avoided by configuring tasks which may be called multiple times, and for which it never makes sense to execute multiple times with the same conditions, so that all but the first call will be ignored:

https://taskfile.dev/usage/#limiting-when-tasks-run