### PR TITLE
Remove unnecessary recursive `.npmrc` coverage from workflow path filters

### DIFF
--- a/.github/workflows/check-markdown-task.yml
+++ b/.github/workflows/check-markdown-task.yml
@@ -8,6 +8,7 @@ on:
     paths:
       - ".github/workflows/check-markdown-task.ya?ml"
       - ".markdown-link-check.json"
+      - ".npmrc"
       - "package.json"
       - "package-lock.json"
       - "Taskfile.ya?ml"
@@ -16,11 +17,11 @@ on:
       - "**.mkdn"
       - "**.mdown"
       - "**.markdown"
-      - "**/.npmrc"
   pull_request:
     paths:
       - ".github/workflows/check-markdown-task.ya?ml"
       - ".markdown-link-check.json"
+      - ".npmrc"
       - "package.json"
       - "package-lock.json"
       - "Taskfile.ya?ml"
@@ -29,7 +30,6 @@ on:
       - "**.mkdn"
       - "**.mdown"
       - "**.markdown"
-      - "**/.npmrc"
   schedule:
     # Run every Tuesday at 8 AM UTC to catch breakage caused by external changes.
     - cron: "0 8 * * TUE"

--- a/.github/workflows/check-prettier-formatting-task.yml
+++ b/.github/workflows/check-prettier-formatting-task.yml
@@ -7,8 +7,8 @@ on:
   push:
     paths:
       - ".github/workflows/check-prettier-formatting-task.ya?ml"
+      - ".npmrc"
       - "Taskfile.ya?ml"
-      - "**/.npmrc"
       - "**/.prettierignore"
       - "**/.prettierrc*"
       # Prettier-covered file patterns are defined by:
@@ -113,8 +113,8 @@ on:
   pull_request:
     paths:
       - ".github/workflows/check-prettier-formatting-task.ya?ml"
+      - ".npmrc"
       - "Taskfile.ya?ml"
-      - "**/.npmrc"
       - "**/.prettierignore"
       - "**/.prettierrc*"
       # CSS

--- a/.github/workflows/check-taskfiles.yml
+++ b/.github/workflows/check-taskfiles.yml
@@ -7,17 +7,17 @@ on:
   push:
     paths:
       - ".github/workflows/check-taskfiles.ya?ml"
+      - ".npmrc"
       - "package.json"
       - "package-lock.json"
-      - "**/.npmrc"
       - "**/Taskfile.ya?ml"
       - "**/DistTasks.ya?ml"
   pull_request:
     paths:
       - ".github/workflows/check-taskfiles.ya?ml"
+      - ".npmrc"
       - "package.json"
       - "package-lock.json"
-      - "**/.npmrc"
       - "**/Taskfile.ya?ml"
       - "**/DistTasks.ya?ml"
   schedule:

--- a/.github/workflows/check-workflows-task.yml
+++ b/.github/workflows/check-workflows-task.yml
@@ -6,17 +6,17 @@ on:
   push:
     paths:
       - ".github/workflows/*.ya?ml"
+      - ".npmrc"
       - "package.json"
       - "package-lock.json"
       - "Taskfile.ya?ml"
-      - "**/.npmrc"
   pull_request:
     paths:
       - ".github/workflows/*.ya?ml"
+      - ".npmrc"
       - "package.json"
       - "package-lock.json"
       - "Taskfile.ya?ml"
-      - "**/.npmrc"
   schedule:
     # Run every Tuesday at 8 AM UTC to catch breakage resulting from changes to the JSON schema.
     - cron: "0 8 * * TUE"

--- a/.github/workflows/sync-labels-npm.yml
+++ b/.github/workflows/sync-labels-npm.yml
@@ -11,16 +11,16 @@ on:
     paths:
       - ".github/workflows/sync-labels-npm.ya?ml"
       - ".github/label-configuration-files/*.ya?ml"
+      - ".npmrc"
       - "package.json"
       - "package-lock.json"
-      - "**/.npmrc"
   pull_request:
     paths:
       - ".github/workflows/sync-labels-npm.ya?ml"
       - ".github/label-configuration-files/*.ya?ml"
+      - ".npmrc"
       - "package.json"
       - "package-lock.json"
-      - "**/.npmrc"
   schedule:
     # Run daily at 8 AM UTC to sync with changes to shared label configurations.
     - cron: "0 8 * * *"


### PR DESCRIPTION
For the sake of efficiency, GitHub Workflows should be configured to only be triggered when relevant files are modified. This filtering is done via the `paths` mapping. "Globstar" patterns are supported in paths filters. This will cause the filter to match the matching files in any path under the repository.

Previously, this was done for the `.npmrc` npm configuration file in various workflows. Although this is appropriate in the "Check npm" workflow, which supports checking npm-based projects in subfolders of the repository, it is not appropriate for the other workflows which do not have such support (and likely don't need it).

In order to improve the efficiency of the workflows, the globstars are removed from the `.npmrc` path filters in the workflows where it is not appropriate.