### PR TITLE
Automatically assign per1234 to Dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,8 @@ updates:
   # See: https://docs.github.com/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot
   - package-ecosystem: github-actions
     directory: / # Check the repository's workflows under /.github/workflows/
+    assignees:
+      - per1234
     schedule:
       interval: daily
     labels:


### PR DESCRIPTION
As the primary maintainer of the project infrastructure, it is the responsibility of GitHub user @per1234 to review and merge the pull requests automatically submitted by Dependabot for bumps of outdated project dependencies.

Configuring Dependabot to automatically set the pull request assignment will slightly streamline that process.

This had already been configured for npm and Python package dependencies, but previously the configuration was missing for GitHub Actions action dependencies.