### PR TITLE
Move configuration `env` mapping to top of workflow

### DIFF
--- a/.github/workflows/release-go-crosscompile-task.yml
+++ b/.github/workflows/release-go-crosscompile-task.yml
@@ -1,11 +1,6 @@
 # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/release-go-crosscompile-task.md
 name: Release
 
-on:
-  push:
-    tags:
-      - "[0-9]+.[0-9]+.[0-9]+*"
-
 env:
   # As defined by the Taskfile's PROJECT_NAME variable
   PROJECT_NAME: arduinoOTA
@@ -14,6 +9,11 @@ env:
   # The project's folder on Arduino's download server for uploading builds
   AWS_PLUGIN_TARGET: /arduinoOTA/
   ARTIFACT_PREFIX: dist-
+
+on:
+  push:
+    tags:
+      - "[0-9]+.[0-9]+.[0-9]+*"
 
 jobs:
   create-release-artifacts:


### PR DESCRIPTION
The "Release" GitHub Actions workflow is based on a standardized "template" which is designed to be reusable in any relevant project.

Some project-specific configuration of the the workflow must be done. These are done via workflow environment variables. It will be most convenient to place the `env` mapping were these variables are defined at the top of the workflow to make them easily accessible to the project maintainer.