### PR TITLE
Reduce line length to <=120 in YAML files where feasible

### DIFF
--- a/.github/workflows/release-go-crosscompile-task.yml
+++ b/.github/workflows/release-go-crosscompile-task.yml
@@ -121,7 +121,8 @@ jobs:
         env:
           KEYCHAIN: "sign.keychain"
           INSTALLER_CERT_MAC_PATH: "/tmp/ArduinoCerts2020.p12"
-          KEYCHAIN_PASSWORD: keychainpassword # Arbitrary password for a keychain that exists only for the duration of the job, so not secret
+          # Arbitrary password for a keychain that exists only for the duration of the job, so not secret
+          KEYCHAIN_PASSWORD: keychainpassword
         run: |
           echo "${{ secrets.INSTALLER_CERT_MAC_P12 }}" | base64 --decode > "${{ env.INSTALLER_CERT_MAC_PATH }}"
           security create-keychain -p "${{ env.KEYCHAIN_PASSWORD }}" "${{ env.KEYCHAIN }}"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -32,7 +32,11 @@ vars:
   DEFAULT_GO_MODULE_PATH: ./
   DEFAULT_GO_PACKAGES:
     sh: |
-      echo $(cd {{default .DEFAULT_GO_MODULE_PATH .GO_MODULE_PATH}} && go list ./... | tr '\n' ' ' || echo '"ERROR: Unable to discover Go packages"')
+      echo $(
+        cd {{default .DEFAULT_GO_MODULE_PATH .GO_MODULE_PATH}} &&
+        go list ./... | tr '\n' ' ' ||
+        echo '"ERROR: Unable to discover Go packages"'
+      )
 
 tasks:
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-workflows-task/Taskfile.yml


### PR DESCRIPTION
[120 columns](https://github.com/arduino/tooling-project-assets/blob/3ebb02742786e76d3f51d7d6e48fe80af6c01c73/workflow-templates/assets/check-yaml/.yamllint.yml#L36) is the [recommended](https://github.com/arduino/tooling-project-assets/blob/3ebb02742786e76d3f51d7d6e48fe80af6c01c73/workflow-templates/assets/check-yaml/.yamllint.yml#L35) line length for YAML code in Arduino tooling projects. The [**yamllint**](https://github.com/adrienverge/yamllint) tool used by [the "Check YAML" template](https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/check-yaml-task.md) produces a warning when a line exceeds this length.

This is not a hard limit, and in some cases it is either impossible or not beneficial to make lines less than 120 in length so some violations of the guideline are unavoidable. However, in the case of these particular long lines, breaking them into multiple lines does improve the readability of the code.