### PR TITLE
Expand codespell file exclusions to cover more generated files

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -3,7 +3,7 @@
 [codespell]
 # In the event of a false positive, add the problematic word, in all lowercase, to a comma-separated list here:
 ignore-words-list = ,
-skip = ./.git,./.licenses,__pycache__,go.mod,go.sum,node_modules,./package-lock.json,./poetry.lock,./yarn.lock
+skip = ./.git,./.licenses,__pycache__,go.mod,go.sum,node_modules,./package-lock.json,./poetry.lock,./yarn.lock,./arduinoOTA,./arduinoOTA.exe
 builtin = clear,informal,en-GB_to_en-US
 check-filenames =
 check-hidden =

--- a/.codespellrc
+++ b/.codespellrc
@@ -3,7 +3,7 @@
 [codespell]
 # In the event of a false positive, add the problematic word, in all lowercase, to a comma-separated list here:
 ignore-words-list = ,
-skip = ./.git,./.licenses,__pycache__,node_modules,./go.mod,./go.sum,./package-lock.json,./poetry.lock,./yarn.lock
+skip = ./.git,./.licenses,__pycache__,go.mod,go.sum,node_modules,./package-lock.json,./poetry.lock,./yarn.lock
 builtin = clear,informal,en-GB_to_en-US
 check-filenames =
 check-hidden =


### PR DESCRIPTION
The [**codespell**](https://github.com/codespell-project/codespell) tool is used to check for the presence of commonly misspelled words in the project files. Since we don't have control over their content, automatically generated files should be excluded from such checks for efficiency and to avoid false positives.