### PR TITLE
Use standard position for non-configuration `env` mapping in workflow

### DIFF
--- a/.github/workflows/sync-labels-npm.yml
+++ b/.github/workflows/sync-labels-npm.yml
@@ -1,10 +1,6 @@
 # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/sync-labels-npm.md
 name: Sync Labels
 
-env:
-  CONFIGURATIONS_FOLDER: .github/label-configuration-files
-  CONFIGURATIONS_ARTIFACT_PREFIX: label-configuration-file-
-
 # See: https://docs.github.com/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows
 on:
   push:
@@ -26,6 +22,10 @@ on:
     - cron: "0 8 * * *"
   workflow_dispatch:
   repository_dispatch:
+
+env:
+  CONFIGURATIONS_FOLDER: .github/label-configuration-files
+  CONFIGURATIONS_ARTIFACT_PREFIX: label-configuration-file-
 
 jobs:
   check:


### PR DESCRIPTION
In cases where some project-specific configuration of reusable GitHub Actions workflows must be done via workflow environment variables, the standard practice is to place the global `env` mapping near the top of the workflow to make them easily accessible to the project maintainer. However, in other cases the mapping does not contain any values that require adjustment. In this case, the established practice is to place it after the `on` mapping.

Previously, the `env` mapping of the "Sync Labels" workflow was used to define the project's standard Node.js version, and thus the mapping was placed at the top of the workflow. However, this configuration was obviated by the change to defining the Node.js value in the `package.json` file (https://github.com/arduino/arduinoOTA/pull/124). So the `env` mapping is no longer used for per-project configuration in this workflow and thus it should be moved below the `on` mapping.