### PR TITLE
Add project binary files to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
+/arduinoOTA
+/arduinoOTA.exe
 /node_modules/


### PR DESCRIPTION
When contributors build the project, the generated binary files will be added to the project folder. These files must not be checked into the repository. This can be prevented by adding them to the `.gitignore` file.