### PR TITLE
Increase timeout duration for link check

### DIFF
--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -8,6 +8,7 @@
     }
   ],
   "retryOn429": true,
+  "timeout": "30s",
   "retryCount": 3,
   "aliveStatusCodes": [200, 206]
 }


### PR DESCRIPTION
The [**markdown-link-check**](https://github.com/tcort/markdown-link-check) tool is used to check for broken links in the project's Markdown files.

In addition to the obvious case where a broken link is indicated by an HTTP response status code, the case where the server does not respond must also be covered. [By default, "markdown-link-check" waits 10 s for a response](https://github.com/tcort/markdown-link-check#config-file-format), and considers the link broken if one was not received in that time. It has been found that it occasionally takes more than 10 s to receive a response from some functional links (https://github.com/arduino/arduino-lint/pull/765), and thus the default timeout value was resulting in disruptive false positives from the link check.