### PR TITLE
Add source link for `DEFAULT_GO_PACKAGES` taskfile variable

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -5,6 +5,7 @@ includes:
   dist: ./DistTasks.yml
 
 vars:
+  # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/go-task/Taskfile.yml
   # Path of the project's primary Go module:
   DEFAULT_GO_MODULE_PATH: ./
   DEFAULT_GO_PACKAGES:


### PR DESCRIPTION
These variables come from a reusable asset that is maintained in [a centralized repository](https://github.com/arduino/tooling-project-assets). Documenting its source will facilitate pulling in changes from development in the upstream repository, and also pushing fixes or enhancements that are made to it via this project.