### PR TITLE
Configure codespell to ignore generated files in subfolders

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -3,7 +3,7 @@
 [codespell]
 # In the event of a false positive, add the problematic word, in all lowercase, to a comma-separated list here:
 ignore-words-list = ,
-skip = ./.git,./.licenses,__pycache__,go.mod,go.sum,node_modules,./package-lock.json,./poetry.lock,./yarn.lock,./arduinoOTA,./arduinoOTA.exe
+skip = ./.licenses,.git,__pycache__,node_modules,go.mod,go.sum,package-lock.json,poetry.lock,yarn.lock,./arduinoOTA,./arduinoOTA.exe
 builtin = clear,informal,en-GB_to_en-US
 check-filenames =
 check-hidden =


### PR DESCRIPTION
The "codespell" tool is used to check for commonly misspelled words in the project files.

This check should be performed on all files that are maintained by humans within the project. For the sake of efficiency, it should not be performed on externally maintained or machine generated files, since there is nothing that can be done within the project to resolve any misspelled words detected there. So the "asset" codespell configuration file contains a list of common externally maintained or machine generated paths to exclude.

Previously the exclusions assumed the files would only be present in the root of the repository. Although that is most common, in some cases they may also be present in subfolders under the repository. The list of exclusions is hereby adjusted to cover those paths as well.