### PR TITLE
Use explicit path for GitHub Actions workflows in Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/dependabot/README.md
   # See: https://docs.github.com/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot
   - package-ecosystem: github-actions
-    directory: / # Check the repository's workflows under /.github/workflows/
+    directory: /.github/workflows
     assignees:
       - per1234
     open-pull-requests-limit: 100


### PR DESCRIPTION
The path of the dependencies manifest files must be defined in the Dependabot configuration for each "package ecosystem" entry. When implementing support for managing GitHub Actions workflows dependencies, the Dependabot developers made the inexplicable decision that, unlike any other ecosystem, Dependabot would look for the workflows under the `.github/workflows` subfolder of the specified path, rather than the actual path that is provided. Support for actually using the path specified by the configuration was later added (https://github.com/dependabot/dependabot-core/pull/6189).

Since the configuration required by the original behavior was quite unintuitive, it is hereby changed to the actual path of the workflows in the repository.