### PR TITLE
Avoid excessive indentation in shell commands

### DIFF
--- a/.github/workflows/check-go-task.yml
+++ b/.github/workflows/check-go-task.yml
@@ -121,10 +121,9 @@ jobs:
 
       - name: Check if any fixes were needed
         run: |
-          git \
-            diff \
-              --color \
-              --exit-code
+          git diff \
+            --color \
+            --exit-code
 
   check-style:
     name: check-style (${{ matrix.module.path }})
@@ -201,10 +200,9 @@ jobs:
 
       - name: Check formatting
         run: |
-          git \
-            diff \
-              --color \
-              --exit-code
+          git diff \
+            --color \
+            --exit-code
 
   check-config:
     name: check-config (${{ matrix.module.path }})
@@ -236,7 +234,6 @@ jobs:
 
       - name: Check whether any tidying was needed
         run: |
-          git \
-            diff \
-              --color \
-              --exit-code
+          git diff \
+            --color \
+            --exit-code

--- a/.github/workflows/check-npm-task.yml
+++ b/.github/workflows/check-npm-task.yml
@@ -116,14 +116,12 @@ jobs:
 
       - name: Install npm dependencies
         run: |
-          task \
-            npm:install-deps \
+          task npm:install-deps \
             PROJECT_PATH="${{ matrix.project.path }}"
 
       - name: Check package-lock.json
         run: |
-          git \
-            diff \
-              --color \
-              --exit-code \
-              "${{ matrix.project.path }}/package-lock.json"
+          git diff \
+            --color \
+            --exit-code \
+            "${{ matrix.project.path }}/package-lock.json"

--- a/.github/workflows/check-prettier-formatting-task.yml
+++ b/.github/workflows/check-prettier-formatting-task.yml
@@ -268,13 +268,10 @@ jobs:
           version: 3.x
 
       - name: Format with Prettier
-        run: |
-          task \
-            general:format-prettier
+        run: task general:format-prettier
 
       - name: Check formatting
         run: |
-          git \
-            diff \
-              --color \
-              --exit-code
+          git diff \
+            --color \
+            --exit-code

--- a/.github/workflows/check-yaml-task.yml
+++ b/.github/workflows/check-yaml-task.yml
@@ -108,6 +108,5 @@ jobs:
       - name: Check YAML
         continue-on-error: ${{ matrix.configuration.continue-on-error }}
         run: |
-          task \
-            yaml:lint \
+          task yaml:lint \
             YAMLLINT_FORMAT=${{ matrix.configuration.format }}


### PR DESCRIPTION
The project's GitHub Actions workflows and tasks contain complex shell command lines.

With the use of the line continuation operator, these commands can be split into multiple code lines. This improves readability by providing a visualization of the command structure. It also improves maintainability by making diffs for changes to these commands more clear.

The readability can be further improved by indentation of the subsequent lines of the command in a manner that visually conveys the structure.

Previously, in cases where multiple commands are chained via control or list operators, the subsequent commands were indented relative to the prior command in the chain. Although this did help to visually convey the structure, it also resulted in excessive levels of indentation. It also resulted in some visual ambiguity between indentation used for arguments to a command, and that for subsequent commands in the chain. For these reasons, the determination was made to not indent the subsequent commands in the chain. The structure is communicated by placing the operator linking the commands on a dedicated line.