### PR TITLE
Split shell commands into multiple lines for readability

### DIFF
--- a/.github/workflows/check-go-dependencies-task.yml
+++ b/.github/workflows/check-go-dependencies-task.yml
@@ -92,13 +92,21 @@ jobs:
           version: 3.x
 
       - name: Update dependencies license metadata cache
-        run: task --silent general:cache-dep-licenses
+        run: |
+          task \
+            --silent \
+            general:cache-dep-licenses
 
       - name: Check for outdated cache
         id: diff
         run: |
           git add .
-          if ! git diff --cached --color --exit-code; then
+          if
+            ! git diff \
+              --cached \
+              --color \
+              --exit-code
+          then
             echo
             echo "::error::Dependency license metadata out of sync. See: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/check-go-dependencies-task.md#metadata-cache"
             exit 1

--- a/.github/workflows/check-go-task.yml
+++ b/.github/workflows/check-go-task.yml
@@ -161,7 +161,10 @@ jobs:
       - name: Check style
         env:
           GO_MODULE_PATH: ${{ matrix.module.path }}
-        run: task --silent go:lint
+        run: |
+          task \
+            --silent \
+            go:lint
 
   check-formatting:
     name: check-formatting (${{ matrix.module.path }})

--- a/.github/workflows/check-license.yml
+++ b/.github/workflows/check-license.yml
@@ -80,7 +80,9 @@ jobs:
           ruby-version: ruby # Install latest version
 
       - name: Install licensee
-        run: gem install licensee
+        run: |
+          gem install \
+            licensee
 
       - name: Check license file for ${{ matrix.check-license.path }}
         run: |
@@ -92,14 +94,26 @@ jobs:
           # See: https://github.com/licensee/licensee
           LICENSEE_OUTPUT="$(licensee detect --json --confidence=100)"
 
-          DETECTED_LICENSE_FILE="$(echo "$LICENSEE_OUTPUT" | jq .matched_files[0].filename | tr --delete '\r')"
+          DETECTED_LICENSE_FILE="$(
+            echo "$LICENSEE_OUTPUT" \
+            | \
+            jq .matched_files[0].filename \
+            | \
+            tr --delete '\r'
+          )"
           echo "Detected license file: $DETECTED_LICENSE_FILE"
           if [ "$DETECTED_LICENSE_FILE" != "\"${{ matrix.check-license.expected-filename }}\"" ]; then
             echo "::error file=${DETECTED_LICENSE_FILE}::detected license file $DETECTED_LICENSE_FILE doesn't match expected: ${{ matrix.check-license.expected-filename }}"
             EXIT_STATUS=1
           fi
 
-          DETECTED_LICENSE_TYPE="$(echo "$LICENSEE_OUTPUT" | jq .matched_files[0].matched_license | tr --delete '\r')"
+          DETECTED_LICENSE_TYPE="$(
+            echo "$LICENSEE_OUTPUT" \
+            | \
+            jq .matched_files[0].matched_license \
+            | \
+            tr --delete '\r'
+          )"
           echo "Detected license type: $DETECTED_LICENSE_TYPE"
           if [ "$DETECTED_LICENSE_TYPE" != "\"${{ matrix.check-license.expected-type }}\"" ]; then
             echo "::error file=${DETECTED_LICENSE_FILE}::detected license type $DETECTED_LICENSE_TYPE doesn't match expected \"${{ matrix.check-license.expected-type }}\""

--- a/.github/workflows/release-go-crosscompile-task.yml
+++ b/.github/workflows/release-go-crosscompile-task.yml
@@ -125,9 +125,14 @@ jobs:
           KEYCHAIN_PASSWORD: keychainpassword
         run: |
           echo "${{ secrets.INSTALLER_CERT_MAC_P12 }}" | base64 --decode >"${{ env.INSTALLER_CERT_MAC_PATH }}"
-          security create-keychain -p "${{ env.KEYCHAIN_PASSWORD }}" "${{ env.KEYCHAIN }}"
-          security default-keychain -s "${{ env.KEYCHAIN }}"
-          security unlock-keychain -p "${{ env.KEYCHAIN_PASSWORD }}" "${{ env.KEYCHAIN }}"
+          security create-keychain \
+            -p "${{ env.KEYCHAIN_PASSWORD }}" \
+            "${{ env.KEYCHAIN }}"
+          security default-keychain \
+            -s "${{ env.KEYCHAIN }}"
+          security unlock-keychain \
+            -p "${{ env.KEYCHAIN_PASSWORD }}" \
+            "${{ env.KEYCHAIN }}"
           security import \
             "${{ env.INSTALLER_CERT_MAC_PATH }}" \
             -k "${{ env.KEYCHAIN }}" \
@@ -143,13 +148,18 @@ jobs:
 
       - name: Install gon for code signing and app notarization
         run: |
-          wget -q https://github.com/Bearer/gon/releases/download/v0.0.27/gon_macos.zip
-          unzip gon_macos.zip -d /usr/local/bin
+          wget \
+            -q \
+            https://github.com/Bearer/gon/releases/download/v0.0.27/gon_macos.zip
 
+          unzip \
+            gon_macos.zip \
+            -d /usr/local/bin
       - name: Write gon config to file
         # gon does not allow env variables in config file (https://github.com/mitchellh/gon/issues/20)
         run: |
-          cat >"${{ env.GON_CONFIG_PATH }}" <<EOF
+          cat >"${{ env.GON_CONFIG_PATH }}" \
+          <<EOF
           # See: https://github.com/Bearer/gon#configuration-file
           source = ["${{ env.DIST_DIR }}/${{ env.BUILD_FOLDER }}/${{ env.PROJECT_NAME }}"]
           bundle_id = "cc.arduino.${{ env.PROJECT_NAME }}"
@@ -179,9 +189,14 @@ jobs:
         run: |
           # GitHub's upload/download-artifact actions don't preserve file permissions,
           # so we need to add execution permission back until the action is made to do this.
-          chmod +x "${{ env.BUILD_FOLDER }}/${{ env.PROJECT_NAME }}"
-          tar -czvf "${{ env.PACKAGE_FILENAME }}" "${{ env.BUILD_FOLDER }}/"
+          chmod \
+            +x \
+            "${{ env.BUILD_FOLDER }}/${{ env.PROJECT_NAME }}"
 
+          tar \
+            -czv \
+            -f "${{ env.PACKAGE_FILENAME }}" \
+            "${{ env.BUILD_FOLDER }}/"
       - name: Replace artifact with notarized build
         uses: actions/upload-artifact@v4
         with:
@@ -215,10 +230,19 @@ jobs:
         # to implement auto pre-release based on tag
         id: prerelease
         run: |
-          wget -q -P /tmp https://github.com/fsaintjacques/semver-tool/archive/3.2.0.zip
-          unzip -p /tmp/3.2.0.zip semver-tool-3.2.0/src/semver >/tmp/semver && chmod +x /tmp/semver
-          if [[ "$(/tmp/semver get prerel "${GITHUB_REF/refs\/tags\//}")" ]]; then echo "IS_PRE=true" >> $GITHUB_OUTPUT; fi
+          wget \
+            -q \
+            -P /tmp https://github.com/fsaintjacques/semver-tool/archive/3.2.0.zip
 
+          unzip \
+            -p /tmp/3.2.0.zip semver-tool-3.2.0/src/semver \
+          >/tmp/semver
+          chmod \
+            +x \
+            /tmp/semver
+          if [[ "$(/tmp/semver get prerel "${GITHUB_REF/refs\/tags\//}")" ]]; then
+            echo "IS_PRE=true" >>$GITHUB_OUTPUT
+          fi
       - name: Create Github Release and upload artifacts
         uses: ncipollo/release-action@v1
         with:

--- a/DistTasks.yml
+++ b/DistTasks.yml
@@ -26,10 +26,17 @@ tasks:
       GO386: "softfloat"
     cmds:
       - |
-        go build -o {{.DIST_DIR}}/{{.PLATFORM_DIR}}/{{.PROJECT_NAME}}.exe {{.LDFLAGS}}
+        go build \
+          -o {{.DIST_DIR}}/{{.PLATFORM_DIR}}/{{.PROJECT_NAME}}.exe \
+          {{.LDFLAGS}}
         cd {{.DIST_DIR}}
-        cp ../LICENSE.txt {{.PLATFORM_DIR}}/
-        zip {{.PACKAGE_NAME}} {{.PLATFORM_DIR}}/{{.PROJECT_NAME}}.exe {{.PLATFORM_DIR}}/LICENSE.txt
+        cp \
+          ../LICENSE.txt \
+          {{.PLATFORM_DIR}}/
+        zip \
+          {{.PACKAGE_NAME}} \
+          {{.PLATFORM_DIR}}/{{.PROJECT_NAME}}.exe \
+          {{.PLATFORM_DIR}}/LICENSE.txt
     vars:
       PLATFORM_DIR: "{{.PROJECT_NAME}}_windows_386"
       PACKAGE_PLATFORM: "Windows_32bit"
@@ -42,10 +49,17 @@ tasks:
       GOARCH: "amd64"
     cmds:
       - |
-        go build -o {{.DIST_DIR}}/{{.PLATFORM_DIR}}/{{.PROJECT_NAME}}.exe {{.LDFLAGS}}
+        go build \
+          -o {{.DIST_DIR}}/{{.PLATFORM_DIR}}/{{.PROJECT_NAME}}.exe \
+          {{.LDFLAGS}}
         cd {{.DIST_DIR}}
-        cp ../LICENSE.txt {{.PLATFORM_DIR}}/
-        zip {{.PACKAGE_NAME}} {{.PLATFORM_DIR}}/{{.PROJECT_NAME}}.exe {{.PLATFORM_DIR}}/LICENSE.txt
+        cp \
+          ../LICENSE.txt \
+          {{.PLATFORM_DIR}}/
+        zip \
+          {{.PACKAGE_NAME}} \
+          {{.PLATFORM_DIR}}/{{.PROJECT_NAME}}.exe \
+          {{.PLATFORM_DIR}}/LICENSE.txt
     vars:
       PLATFORM_DIR: "{{.PROJECT_NAME}}_windows_amd64"
       PACKAGE_PLATFORM: "Windows_64bit"
@@ -59,10 +73,16 @@ tasks:
       GO386: "softfloat"
     cmds:
       - |
-        go build -o {{.DIST_DIR}}/{{.PLATFORM_DIR}}/{{.PROJECT_NAME}} {{.LDFLAGS}}
+        go build \
+          -o {{.DIST_DIR}}/{{.PLATFORM_DIR}}/{{.PROJECT_NAME}} \
+          {{.LDFLAGS}}
         cd {{.DIST_DIR}}
-        cp ../LICENSE.txt {{.PLATFORM_DIR}}/
-        tar cz {{.PLATFORM_DIR}} -f {{.PACKAGE_NAME}}
+        cp \
+          ../LICENSE.txt \
+          {{.PLATFORM_DIR}}/
+        tar cz \
+          {{.PLATFORM_DIR}} \
+          -f {{.PACKAGE_NAME}}
     vars:
       PLATFORM_DIR: "{{.PROJECT_NAME}}_linux_amd32"
       PACKAGE_PLATFORM: "Linux_32bit"
@@ -75,10 +95,16 @@ tasks:
       GOARCH: "amd64"
     cmds:
       - |
-        go build -o {{.DIST_DIR}}/{{.PLATFORM_DIR}}/{{.PROJECT_NAME}} {{.LDFLAGS}}
+        go build \
+          -o {{.DIST_DIR}}/{{.PLATFORM_DIR}}/{{.PROJECT_NAME}} \
+          {{.LDFLAGS}}
         cd {{.DIST_DIR}}
-        cp ../LICENSE.txt {{.PLATFORM_DIR}}/
-        tar cz {{.PLATFORM_DIR}} -f {{.PACKAGE_NAME}}
+        cp \
+          ../LICENSE.txt \
+          {{.PLATFORM_DIR}}/
+        tar cz \
+          {{.PLATFORM_DIR}} \
+          -f {{.PACKAGE_NAME}}
     vars:
       PLATFORM_DIR: "{{.PROJECT_NAME}}_linux_amd64"
       PACKAGE_PLATFORM: "Linux_64bit"
@@ -92,10 +118,16 @@ tasks:
       GOARM: 7
     cmds:
       - |
-        go build -o {{.DIST_DIR}}/{{.PLATFORM_DIR}}/{{.PROJECT_NAME}} {{.LDFLAGS}}
+        go build \
+          -o {{.DIST_DIR}}/{{.PLATFORM_DIR}}/{{.PROJECT_NAME}} \
+          {{.LDFLAGS}}
         cd {{.DIST_DIR}}
-        cp ../LICENSE.txt {{.PLATFORM_DIR}}/
-        tar cz {{.PLATFORM_DIR}} -f {{.PACKAGE_NAME}}
+        cp \
+          ../LICENSE.txt \
+          {{.PLATFORM_DIR}}/
+        tar cz \
+          {{.PLATFORM_DIR}} \
+          -f {{.PACKAGE_NAME}}
     vars:
       PLATFORM_DIR: "{{.PROJECT_NAME}}_linux_arm_7"
       PACKAGE_PLATFORM: "Linux_ARMv7"
@@ -109,10 +141,16 @@ tasks:
       GOARM: 6
     cmds:
       - |
-        go build -o {{.DIST_DIR}}/{{.PLATFORM_DIR}}/{{.PROJECT_NAME}} {{.LDFLAGS}}
+        go build \
+          -o {{.DIST_DIR}}/{{.PLATFORM_DIR}}/{{.PROJECT_NAME}} \
+          {{.LDFLAGS}}
         cd {{.DIST_DIR}}
-        cp ../LICENSE.txt {{.PLATFORM_DIR}}/
-        tar cz {{.PLATFORM_DIR}} -f {{.PACKAGE_NAME}}
+        cp \
+          ../LICENSE.txt \
+          {{.PLATFORM_DIR}}/
+        tar cz \
+          {{.PLATFORM_DIR}} \
+          -f {{.PACKAGE_NAME}}
     vars:
       PLATFORM_DIR: "{{.PROJECT_NAME}}_linux_arm_6"
       PACKAGE_PLATFORM: "Linux_ARMv6"
@@ -125,10 +163,16 @@ tasks:
       GOARCH: "arm64"
     cmds:
       - |
-        go build -o {{.DIST_DIR}}/{{.PLATFORM_DIR}}/{{.PROJECT_NAME}} {{.LDFLAGS}}
+        go build \
+          -o {{.DIST_DIR}}/{{.PLATFORM_DIR}}/{{.PROJECT_NAME}} \
+          {{.LDFLAGS}}
         cd {{.DIST_DIR}}
-        cp ../LICENSE.txt {{.PLATFORM_DIR}}/
-        tar cz {{.PLATFORM_DIR}} -f {{.PACKAGE_NAME}}
+        cp \
+          ../LICENSE.txt \
+          {{.PLATFORM_DIR}}/
+        tar cz \
+          {{.PLATFORM_DIR}} \
+          -f {{.PACKAGE_NAME}}
     vars:
       PLATFORM_DIR: "{{.PROJECT_NAME}}_linux_arm_64"
       PACKAGE_PLATFORM: "Linux_ARM64"
@@ -141,10 +185,16 @@ tasks:
       GOARCH: "amd64"
     cmds:
       - |
-        go build -o {{.DIST_DIR}}/{{.PLATFORM_DIR}}/{{.PROJECT_NAME}} {{.LDFLAGS}}
+        go build \
+          -o {{.DIST_DIR}}/{{.PLATFORM_DIR}}/{{.PROJECT_NAME}} \
+          {{.LDFLAGS}}
         cd {{.DIST_DIR}}
-        cp ../LICENSE.txt {{.PLATFORM_DIR}}/
-        tar cz {{.PLATFORM_DIR}} -f {{.PACKAGE_NAME}}
+        cp \
+          ../LICENSE.txt \
+          {{.PLATFORM_DIR}}/
+        tar cz \
+          {{.PLATFORM_DIR}} \
+          -f {{.PACKAGE_NAME}}
     vars:
       PLATFORM_DIR: "{{.PROJECT_NAME}}_osx_darwin_amd64"
       PACKAGE_PLATFORM: "macOS_64bit"
@@ -157,10 +207,16 @@ tasks:
       GOARCH: "arm64"
     cmds:
       - |
-        go build -o {{.DIST_DIR}}/{{.PLATFORM_DIR}}/{{.PROJECT_NAME}} {{.LDFLAGS}}
+        go build \
+          -o {{.DIST_DIR}}/{{.PLATFORM_DIR}}/{{.PROJECT_NAME}} \
+          {{.LDFLAGS}}
         cd {{.DIST_DIR}}
-        cp ../LICENSE.txt {{.PLATFORM_DIR}}/
-        tar cz {{.PLATFORM_DIR}} -f {{.PACKAGE_NAME}}
+        cp \
+          ../LICENSE.txt \
+          {{.PLATFORM_DIR}}/
+        tar cz \
+          {{.PLATFORM_DIR}} \
+          -f {{.PACKAGE_NAME}}
     vars:
       PLATFORM_DIR: "{{.PROJECT_NAME}}_osx_darwin_arm64"
       PACKAGE_PLATFORM: "macOS_ARM64"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -22,13 +22,34 @@ vars:
   DIST_DIR: "dist"
   # build vars
   COMMIT:
-    sh: echo "$(git log --no-show-signature -n 1 --format=%h)"
+    sh: |
+      echo \
+        "$(
+          git log \
+            --no-show-signature \
+            -n 1 \
+            --format=%h
+        )"
   TIMESTAMP:
-    sh: echo "$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+    sh: |
+      echo \
+        "$(
+          date \
+            -u \
+            +"%Y-%m-%dT%H:%M:%SZ"
+        )"
   TIMESTAMP_SHORT:
     sh: echo "{{now | date "20060102"}}"
   TAG:
-    sh: echo "$(git tag --points-at=HEAD 2> /dev/null | head -n1)"
+    sh: |
+      echo \
+        "$(
+          git tag \
+            --points-at=HEAD \
+          2>/dev/null \
+          | \
+          head -n1
+        )"
   VERSION: "{{if .NIGHTLY}}nightly-{{.TIMESTAMP_SHORT}}{{else if .TAG}}{{.TAG}}{{else}}{{.PACKAGE_NAME_PREFIX}}git-snapshot{{end}}"
   CONFIGURATION_PACKAGE: "github.com/arduino/arduinoOTA/version"
   LDFLAGS: >-
@@ -111,7 +132,10 @@ tasks:
     desc: Check basic formatting style of all files
     cmds:
       - |
-        if ! which ec &>/dev/null; then
+        if
+          ! which ec \
+          &>/dev/null
+        then
           echo "ec not found or not in PATH."
           echo "Please install: https://github.com/editorconfig-checker/editorconfig-checker#installation"
           exit 1
@@ -281,7 +305,7 @@ tasks:
       - |
         npx \
           markdownlint-cli \
-          "**/*.md"
+            "**/*.md"
 
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/npm-task/Taskfile.yml
   npm:install-deps:
@@ -459,10 +483,17 @@ tasks:
   utility:normalize-path:
     cmds:
       - |
-        if [[ "{{.OS}}" == "Windows_NT" ]] && which cygpath &>/dev/null; then
-            # Even though the shell handles POSIX format absolute paths as expected, external applications do not.
-            # So paths passed to such applications must first be converted to Windows format.
-            cygpath -w "{{.RAW_PATH}}"
+        if
+          [[ "{{.OS}}" == "Windows_NT" ]] \
+          && \
+          which cygpath \
+          &>/dev/null
+        then
+          # Even though the shell handles POSIX format absolute paths as expected, external applications do not.
+          # So paths passed to such applications must first be converted to Windows format.
+          cygpath \
+            -w \
+            "{{.RAW_PATH}}"
         else
           echo "{{.RAW_PATH}}"
         fi


### PR DESCRIPTION
The project's GitHub Actions workflows and tasks contain complex shell command lines.

With the use of the line continuation operator, these commands can be split into multiple code lines. This improves readability by providing a visualization of the command structure and avoiding excessive line lengths. It also improves maintainability by making diffs for changes to these commands more clear.

Previously this was done in many commands, but not consistently throughout the project.