### PR TITLE
Remove trailing slash from path variable values

### DIFF
--- a/.github/workflows/check-go-task.yml
+++ b/.github/workflows/check-go-task.yml
@@ -97,7 +97,7 @@ jobs:
 
       matrix:
         module:
-          - path: ./
+          - path: .
 
     steps:
       - name: Checkout repository
@@ -138,7 +138,7 @@ jobs:
 
       matrix:
         module:
-          - path: ./
+          - path: .
 
     steps:
       - name: Checkout repository
@@ -179,7 +179,7 @@ jobs:
 
       matrix:
         module:
-          - path: ./
+          - path: .
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/check-license.yml
+++ b/.github/workflows/check-license.yml
@@ -65,7 +65,7 @@ jobs:
 
       matrix:
         check-license:
-          - path: ./
+          - path: .
             expected-filename: LICENSE.txt
             # SPDX identifier: https://spdx.org/licenses/
             expected-type: GPL-3.0

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -7,7 +7,7 @@ includes:
 vars:
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/go-task/Taskfile.yml
   # Path of the project's primary Go module:
-  DEFAULT_GO_MODULE_PATH: ./
+  DEFAULT_GO_MODULE_PATH: .
   DEFAULT_GO_PACKAGES:
     sh: |
       echo $(
@@ -16,7 +16,7 @@ vars:
         echo '"ERROR: Unable to discover Go packages"'
       )
   # Path of the primary npm-managed project:
-  DEFAULT_NPM_PROJECT_PATH: ./
+  DEFAULT_NPM_PROJECT_PATH: .
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/release-go-task/Taskfile.yml
   PROJECT_NAME: "arduinoOTA"
   DIST_DIR: "dist"


### PR DESCRIPTION
Paths in some workflows and tasks are configured via variables. Previously, when a value specified a folder path, a trailing slash was added. The intent behind this was to make it slightly more clear that the value was referring to a folder (e.g., `./` vs. `.`). However, this practice can be harmful in the case where the value is used as a base component in a path, as then it is most appropriate to omit the path separator in the concatenation code, which is at all clear (e.g., `FOO_PATH: foo/`, `{{.FOO_PATH}}bar` -> `foo/bar`). And if the separator is used in the concatenation
code, it results in a confusing double separator in the resulting path (e.g., `FOO_PATH: foo/`, `{{.FOO_PATH}}/bar` ->
`foo//bar`). The benefit of the trailing slash on the variable definition is miniscule at most, since the variable name, documentation, and other context should make it obvious that the value is a folder path. So the harm of this approach outweighs the benefit.

For this reason, it is better to omit the trailing slash in the variable definition (e.g., `FOO_PATH: foo`, `{{.FOO_PATH}}/bar` -> `foo/bar`). Even though this approach is not relevant in cases where the path is not used as a base component, it is best to be consistent in this practice.