### PR TITLE
Use relevant metadata file when determining Node.js version

### DIFF
--- a/.github/workflows/check-npm-task.yml
+++ b/.github/workflows/check-npm-task.yml
@@ -106,7 +106,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
-          node-version-file: package.json
+          node-version-file: "${{ matrix.project.path }}/package.json"
 
       - name: Install Task
         uses: arduino/setup-task@v2


### PR DESCRIPTION
This workflow job supports projects with multiple npm projects in subfolders of the repository. The version of Node.js to use is determined from the content of the npm metadata file. Previously the workflow always used the file located in the root of the repository. The versioning data in that file won't necessarily be correct for npm projects in subfolders, so the metadata for the individual npm project should be used instead.