### PR TITLE
Check/fix problems with npm configuration

### DIFF
--- a/.github/workflows/check-npm-task.yml
+++ b/.github/workflows/check-npm-task.yml
@@ -125,3 +125,45 @@ jobs:
             --color \
             --exit-code \
             "${{ matrix.project.path }}/package-lock.json"
+
+  check-config:
+    name: check-config (${{ matrix.project.path }})
+    needs: run-determination
+    if: needs.run-determination.outputs.result == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        project:
+          # TODO: add paths of all npm-managed projects in the repository here.
+          - path: .
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: "${{ matrix.project.path }}/package.json"
+
+      - name: Install Task
+        uses: arduino/setup-task@v2
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: 3.x
+
+      - name: Fix problems in npm configuration file
+        run: |
+          task npm:fix-config \
+            PROJECT_PATH="${{ matrix.project.path }}"
+
+      - name: Check if fixes are needed in npm configuration file
+        run: |
+          git diff \
+            --color \
+            --exit-code \
+            "${{ matrix.project.path }}/.npmrc"

--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,3 @@
 # See: https://docs.npmjs.com/cli/configuring-npm/npmrc
 
-engine-strict = true
+engine-strict=true

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -307,6 +307,19 @@ tasks:
           markdownlint-cli \
             "**/*.md"
 
+  # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-npm-task/Taskfile.yml
+  npm:fix-config:
+    desc: |
+      Fix problems with the npm configuration file.
+      Environment variable parameters:
+      - PROJECT_PATH: Path of the npm-managed project (default: {{.DEFAULT_NPM_PROJECT_PATH}}).
+    dir: "{{default .DEFAULT_NPM_PROJECT_PATH .PROJECT_PATH}}"
+    cmds:
+      - |
+        npm config \
+          --location project \
+          fix
+
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/npm-task/Taskfile.yml
   npm:install-deps:
     desc: |


### PR DESCRIPTION
The "Check npm" template provides actions and a GitHub Actions workflow used to check for problems with a project's npm configuration files.

In addition to the `package.json` file previously used, we are now using an `.npmrc` configuration file. It will be useful to have some validation for this file. npm provides a `config fix` command which automatically fixes any problems that are detected with the npm configuration. In addition to using it for that purpose, it can also serve as a check by running the command via the GitHub Actions workflow, then checking for any diff.

Beyond the automated fixes, it is hoped that the parsing of the configuration that npm must perform to check for any needed fixes provides a basic validation of the configuration. Unfortunately npm's parser is extremely lenient, so the validation is not at all comprehensive. However, it is probably better than nothing, simple to implement, and no alternatives were found.