### PR TITLE
Add source comments to reusable infrastructure components

### DIFF
--- a/.github/workflows/check-poetry-task.yml
+++ b/.github/workflows/check-poetry-task.yml
@@ -67,7 +67,7 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           version: 3.x
 
-      - name: Validate pyproject.toml
+      - name: Validate configuration
         run: |
           task \
             --silent \

--- a/.github/workflows/check-poetry-task.yml
+++ b/.github/workflows/check-poetry-task.yml
@@ -1,3 +1,4 @@
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/check-poetry-task.md
 name: Check Poetry
 
 on:

--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,4 @@
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/npm/.npmrc
 # See: https://docs.npmjs.com/cli/configuring-npm/npmrc
 
 engine-strict=true

--- a/.prettierrc.yml
+++ b/.prettierrc.yml
@@ -1,2 +1,3 @@
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-prettier-formatting/toml/.prettierrc.yml
 plugins:
   - prettier-plugin-toml

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -15,6 +15,7 @@ vars:
         go list ./... | tr '\n' ' ' ||
         echo '"ERROR: Unable to discover Go packages"'
       )
+  # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/npm-task/Taskfile.yml
   # Path of the primary npm-managed project:
   DEFAULT_NPM_PROJECT_PATH: .
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/release-go-task/Taskfile.yml
@@ -413,6 +414,7 @@ tasks:
             -r "{{.STYLELINTRC_SCHEMA_PATH}}" \
             -d "{{.INSTANCE_PATH}}"
 
+  # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/poetry-task/Taskfile.yml
   poetry:install:
     desc: Install Poetry
     run: once
@@ -458,6 +460,7 @@ tasks:
         poetry install \
           {{if .POETRY_GROUPS}} --only {{.POETRY_GROUPS}} {{end}}
 
+  # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-poetry-task/Taskfile.yml
   poetry:sync:
     desc: Sync poetry.lock
     deps:
@@ -467,6 +470,7 @@ tasks:
         poetry lock \
           --no-cache
 
+  # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-poetry-task/Taskfile.yml
   poetry:validate:
     desc: Validate pyproject.toml
     deps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,5 @@
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/poetry/pyproject.toml
+
 [tool.poetry]
 package-mode = false
 


### PR DESCRIPTION
The project infrastructure uses reusable components that are maintained in a centralized repository. Documenting the source of these components facilitates maintenance, either by pulling in changes made upstream, or pushing locally implemented changes back upstream.