### PR TITLE
Explicitly specify npm project path in task calls

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -78,6 +78,8 @@ tasks:
       WORKFLOWS_DATA_PATH: "./.github/workflows/*.{yml,yaml}"
     deps:
       - task: npm:install-deps
+        vars:
+          PROJECT_PATH: .
     cmds:
       - |
         wget \
@@ -148,6 +150,8 @@ tasks:
     desc: Format all supported files with Prettier
     deps:
       - task: npm:install-deps
+        vars:
+          PROJECT_PATH: .
     cmds:
       - |
         npx \
@@ -279,6 +283,8 @@ tasks:
     deps:
       - task: docs:generate
       - task: npm:install-deps
+        vars:
+          PROJECT_PATH: .
     cmds:
       - |
         npx \
@@ -290,6 +296,8 @@ tasks:
     desc: Automatically correct linting violations in Markdown files where possible
     deps:
       - task: npm:install-deps
+        vars:
+          PROJECT_PATH: .
     cmds:
       - |
         npx \
@@ -302,6 +310,8 @@ tasks:
     desc: Check for problems in Markdown files
     deps:
       - task: npm:install-deps
+        vars:
+          PROJECT_PATH: .
     cmds:
       - |
         npx \


### PR DESCRIPTION
Since the `npm:install-deps` task has a default path, it is not mandatory to specify a path in the task calls. However, doing so makes the behavior of the caller task more clear