### PR TITLE
Remove superfluous `run` keys from tasks

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -105,7 +105,6 @@ tasks:
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-dependencies-task/Taskfile.yml
   general:cache-dep-licenses:
     desc: Cache dependency license metadata
-    run: when_changed
     deps:
       - task: general:prepare-deps
     cmds:
@@ -187,7 +186,6 @@ tasks:
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-go-dependencies-task/Taskfile.yml
   general:prepare-deps:
     desc: Prepare project dependencies for license check
-    run: when_changed
     # No preparation is needed for Go module-based projects.
 
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/go-task/Taskfile.yml


### PR DESCRIPTION
The "Task" task runner tool is used to perform common development operations for the project.

Tasks may call other tasks. Under certain conditions, this can result in the same task being called redundantly. This can be avoided by using the `run` key to configure so that all but the first call will be ignored.

Previously such a configuration was used in some tasks which will never be called redundantly. That configuration only makes the tasks more difficult to understand and maintain, without any benefit. For this reason, the `run` keys are removed from these tasks.