### PR TITLE
Use more appropriate `run` key configuration for `poetry:install` task

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -425,7 +425,7 @@ tasks:
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/poetry-task/Taskfile.yml
   poetry:install:
     desc: Install Poetry
-    run: once
+    run: when_changed
     cmds:
       - |
         if ! which pipx &>/dev/null; then


### PR DESCRIPTION
The "Task" task runner tool is used to perform common development operations for the project.

Tasks may call other tasks. Under certain conditions, this can result in the same task being called redundantly. This can be avoided by using the `run` key to configure the task so that redundant calls will be skipped.

Previously, the `poetry:install` task's `run` key was set to `once`, which causes all but the first call will be skipped. A safer configuration is `when_changed`, which will skip subsequent calls, unless the task configuration has changed.