### PR TITLE
Print instructions for false positive resolution when spell check fails

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -167,8 +167,15 @@ tasks:
           POETRY_GROUPS: dev
     cmds:
       - |
-        poetry run \
-          codespell
+        if ! {
+          poetry run \
+            codespell
+        }; then
+          echo
+          echo "If this was a false positive, add the word to the ignore list:"
+          echo "https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/spell-check-task.md#false-positives"
+          exit 1
+        fi
 
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/spell-check-task/Taskfile.yml
   general:correct-spelling:


### PR DESCRIPTION
The assets include infrastructure to check for commonly misspelled words in the project files.

Although the system is designed to reduce the incidence of false positives, they are still relatively common. For this reason, it is important to clearly communicate to the contributor how such false positives can be resolved. This can be accomplished effectively by printing instructions when the spell check fails.

In order to avoid excessive verbosity of the output (note that the failure could just as well be a true positive), the description of the procedure is maintained in the asset documentation and the output message simply provides the URL of that documentation.