### PR TITLE
Refactor `poetry:install` task

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -451,15 +451,18 @@ tasks:
           task utility:normalize-path \
             RAW_PATH="$(which python)" \
         )"
+
+        poetry_constraint="$( \
+          yq \
+            --input-format toml \
+            --output-format yaml \
+            '.tool.poetry.group.pipx.dependencies.poetry' \
+          <pyproject.toml
+        )"
+
         pipx install \
           --force \
-          "poetry==$( \
-            yq \
-              --input-format toml \
-              --output-format yaml \
-              '.tool.poetry.group.pipx.dependencies.poetry' \
-              < pyproject.toml
-          )"
+          "poetry==$poetry_constraint"
 
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/poetry-task/Taskfile.yml
   poetry:install-deps:


### PR DESCRIPTION
Separating the complex version determination code from the installation command makes it easier to understand the task code.